### PR TITLE
chore: v0.3.1 — Dependency updates

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           cp benchmark-results.txt benchmark-output/
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: benchmark-output/
@@ -104,7 +104,7 @@ jobs:
           echo '```' >> comparison.md
 
       - name: Upload comparison
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-comparison
           path: comparison.md
@@ -157,7 +157,7 @@ jobs:
           echo '```' >> gpu-comparison/report.md
 
       - name: Upload GPU comparison
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: gpu-cpu-comparison
           path: gpu-comparison/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: node scripts/post-wasm-build.js
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-build
           path: cliffy-wasm/pkg/
@@ -149,7 +149,7 @@ jobs:
           node-version: '20'
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-build
           path: cliffy-wasm/pkg/
@@ -167,7 +167,7 @@ jobs:
         run: npm run build:all --if-present || npm run build -ws --if-present
 
       - name: Upload example builds
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: examples-build
           path: |
@@ -207,7 +207,7 @@ jobs:
           node-version: '20'
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-build
           path: cliffy-wasm/pkg/
@@ -236,7 +236,7 @@ jobs:
         run: npx playwright test --project="$BROWSER"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.os }}-${{ matrix.browser }}
@@ -307,7 +307,7 @@ jobs:
         run: cp -r src/templates dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: create-cliffy
           path: tools/create-cliffy/dist/
@@ -326,7 +326,7 @@ jobs:
           node-version: '20'
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-build
           path: cliffy-wasm/pkg/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             --release
       
       - name: Upload WASM release artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-release
           path: cliffy-wasm/pkg/
@@ -74,7 +74,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: wasm-release
           path: cliffy-wasm/pkg/
@@ -95,7 +95,7 @@ jobs:
           npm pack
       
       - name: Upload NPM package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: npm-package
           path: cliffy-typescript/*.tgz
@@ -115,7 +115,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       
       - name: Download NPM package
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: npm-package
           path: .
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
       
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,546 +1,134 @@
 # Technical Backlog
 
-This document tracks technical debt, integration gaps, and planned work items discovered during development—particularly during documentation phases where gaps become visible.
-
-## Organization
-
-Items are categorized by:
-- **Priority**: High (blocks user experience), Medium (developer experience), Low (polish)
-- **Origin**: Which phase revealed the issue
-- **Related Phase**: Which phase should address it
+Work items organized by target release. See [ROADMAP.md](./ROADMAP.md) for full context on each milestone.
 
 ---
 
-## High Priority (Blocks User Experience)
-
-### Export/Packaging Issues
-
-- [x] **Export `html.ts` from `cliffy-wasm` package** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4 (Algebraic TSX)
-  - Issue: The `html` tagged template function exists in `cliffy-wasm/src/html.ts` but isn't bundled with the WASM package. Templates must include it locally.
-  - Fix: Created post-build script that copies html.ts to pkg/ and updates package.json exports
-  - Status: Completed - Import via `import { html, mount } from 'cliffy-wasm/html'`
-
-- [x] **Create main `Cliffy.purs` module** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4 (Algebraic TSX)
-  - Issue: PureScript FFI files exist (`Cliffy.Html`, `Cliffy.Html.Attributes`, `Cliffy.Html.Events`) but there's no main `Cliffy` module that re-exports `behavior`, `event`, `update`, `subscribe`, etc.
-  - Fix: Created `cliffy-purescript/src/Cliffy.purs` with FRP primitive re-exports
-  - Status: Completed - Added Behavior/Event types and FFI bindings
-
-- [x] **Wire up PureScript package dependencies** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4 (Algebraic TSX)
-  - Issue: `spago.dhall` template doesn't reference `cliffy-purescript` package
-  - Fix: Added git dependency with subdir to `packages.dhall.template`
-  - Status: Completed - Template now references cliffy-purescript from Cliffy monorepo
-
-### API Completeness
-
-- [ ] **Implement `initHtml()` integration**
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4 (Algebraic TSX)
-  - Issue: `html.ts` requires `initHtml(DOMProjection)` call but `DOMProjection` isn't exported from WASM
-  - Fix: Export `DOMProjection` from cliffy-wasm or remove dependency
-
----
-
-## Medium Priority (Developer Experience)
-
-### Consistency Issues
-
-- [ ] **Unify TypeScript/PureScript API naming**
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4, Phase 8
-  - Issue: Some naming inconsistencies between TS and PS APIs
-  - Examples:
-    - TS: `count.update(n => n + 1)` vs PS: `update (_ + 1) count`
-    - TS: `className` vs PS: `className` (this one is consistent)
-  - Fix: Document intentional differences, fix unintentional ones
-
-- [ ] **Add TypeScript type definitions for html.ts**
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4 (Algebraic TSX)
-  - Issue: `html.ts` uses `any` casts and lacks strict typing in some places
-  - Fix: Add proper generic types and remove `any` usage
-
-### Documentation Gaps
-
-- [x] **Document Behavior.map() vs Array.map() distinction** ✅
-  - Origin: Phase 7 (Documentation)
-  - Status: Added note in getting-started.md
-  - Related: Phase 7
-
-- [x] **Create Algebraic TSX migration guide** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 7
-  - Issue: No guide for migrating from React/Vue to Algebraic TSX patterns
-  - Fix: Created docs/migration-guide.md with React/Vue comparison patterns
-
----
-
-## Low Priority (Polish)
-
-### Code Quality
-
-- [ ] **Remove `any` types from Foreign.js**
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4
-  - Issue: PureScript FFI uses untyped JavaScript
-  - Fix: Add JSDoc types or convert to TypeScript
-
-- [ ] **Add cleanup for orphaned subscriptions**
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4
-  - Issue: Potential memory leaks if components unmount without proper cleanup
-  - Fix: Add WeakRef-based cleanup or explicit disposal pattern
-
----
-
-## Amari 0.19.0 Upgrade (Phase 9.5)
-
-### cliffy-test: SMT Backend + Statistical Bounds
-
-- [ ] **Bump amari-flynn 0.17.0 → 0.19.0**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: High
-  - Note: rand 0.8 → check compatibility with new amari-flynn; may need rand version bump
-
-- [ ] **Add SMT proof export to invariants**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: High
-  - Details:
-    - `ImpossibleInvariant::export_smt()` → `precondition_obligation(name, desc, 1.0)`
-    - `RareInvariant::export_smt()` → `hoeffding_obligation(name, samples, epsilon, delta)`
-    - Both return `SmtProofObligation` that can be written to `.smt2` files
-    - Add `verify_with_smt()` that cross-verifies Monte Carlo vs SMT
-
-- [ ] **Enrich InvariantTestReport with statistical bounds**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Medium
-  - Details:
-    - Add `confidence_interval: Option<(f64, f64)>` field
-    - Use `MonteCarloVerifier::estimate_probability()` → returns (estimate, lower, upper)
-    - Use `hoeffding_bound(n, epsilon)` to compute required sample count
-    - Use `compute_confidence(samples, epsilon)` for confidence level
-    - Use `confidence_interval(successes, total, confidence)` for CI
+## v0.4.0 — Typed Algebra
 
 ### cliffy-core: Typed Rotor API
 
-- [ ] **Replace raw GA3 rotation with Rotor<3,0,0>**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Medium
-  - Details:
-    - `GeometricState` rotation via `Rotor::apply()` instead of manual sandwich
-    - `GeometricState.blend()` via `Rotor::slerp()` for correct manifold interpolation
-    - Transform composition via `Rotor::compose()`
-    - Rotor construction via `Rotor::from_vectors()` where applicable
-
-- [ ] **Replace raw GA3 vectors with Vector<3,0,0>**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Medium
-  - Details:
-    - Position/displacement as `Vector<3,0,0>`
-    - `Vector::normalize()` and `Vector::norm()` for typed operations
+- [ ] Replace raw GA3 rotation with `Rotor<3,0,0>` — `GeometricState` rotation via `Rotor::apply()` instead of manual sandwich
+- [ ] Replace raw GA3 vectors with `Vector<3,0,0>` — position/displacement with `Vector::normalize()` and `Vector::norm()`
+- [ ] `GeometricState.blend()` via `Rotor::slerp()` for correct manifold interpolation
+- [ ] Transform composition via `Rotor::compose()`
+- [ ] Rotor construction via `Rotor::from_vectors()` where applicable
 
 ### cliffy-protocols: Type-Safe Distributed State
 
-- [ ] **Type CRDT operations with Rotor/Vector/Bivector**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: High
-  - Details:
-    - `GeometricOp::Sandwich` → takes `Rotor<3,0,0>`, uses `Rotor::apply()`
-    - `GeometricOp::Exponential` → takes `Bivector<3,0,0>`, uses `exp()` then `Rotor::apply()`
-    - Operation composition via `Rotor::compose()`
+- [ ] Type CRDT operations with Rotor/Vector/Bivector
+  - `GeometricOp::Sandwich` → takes `Rotor<3,0,0>`, uses `Rotor::apply()`
+  - `GeometricOp::Exponential` → takes `Bivector<3,0,0>`, uses `exp()` then `Rotor::apply()`
+  - Operation composition via `Rotor::compose()`
+- [ ] Type delta encodings
+  - `DeltaEncoding::Additive` wraps `Vector<3,0,0>` (displacement)
+  - `DeltaEncoding::Multiplicative` wraps `Rotor<3,0,0>` (transformation)
+  - `DeltaEncoding::Compressed` wraps `Bivector<3,0,0>` (log-space)
+  - Use `Rotor::logarithm()` and `Multivector::exp()` for compressed encoding
+- [ ] Use `Rotor::slerp()` for consensus — iterative slerp for Fréchet mean, `Rotor::power(weight)` for weighted proposals
+- [ ] `norm_squared()` for magnitude comparisons — replace `magnitude()` in lattice comparisons, use `grade_magnitude()` for grade-aware operations
+- [ ] Storage integrity with `VerifiedMultivector` — validate multivectors on snapshot load (requires amari-core `phantom-types` feature)
 
-- [ ] **Type delta encodings**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Medium
-  - Details:
-    - `DeltaEncoding::Additive` wraps `Vector<3,0,0>` (displacement)
-    - `DeltaEncoding::Multiplicative` wraps `Rotor<3,0,0>` (transformation)
-    - `DeltaEncoding::Compressed` wraps `Bivector<3,0,0>` (log-space)
-    - Use `Rotor::logarithm()` and `Multivector::exp()` for compressed encoding
+### cliffy-test: SMT Backend + Statistical Bounds
 
-- [ ] **Use Rotor::slerp() for consensus**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Medium
-  - Details:
-    - `geometric_consensus()` → iterative `Rotor::slerp()` for Fréchet mean
-    - `weighted_geometric_consensus()` → `Rotor::power(weight)` for weighted proposals
-    - Mathematically correct interpolation on rotor manifold
-
-- [ ] **Performance: norm_squared() for magnitude comparisons**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Low
-  - Details:
-    - Replace `magnitude()` with `norm_squared()` in lattice comparisons
-    - Use `grade_magnitude()` for grade-aware lattice operations
-    - Avoids unnecessary sqrt in hot paths
-
-- [ ] **Storage integrity with VerifiedMultivector**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 9.5
-  - Priority: Low
-  - Requires: amari-core `phantom-types` feature
-  - Details:
-    - Validate multivectors on snapshot load via `VerifiedMultivector::new()`
-    - Catches corruption at deserialization boundary
-
-### cliffy-alive: amari-automata Integration (deferred)
-
-- [ ] **Replace custom CA with amari-automata GeometricCA**
-  - Origin: Amari 0.19.0 audit
-  - Related: Phase 11
-  - Priority: Deferred
-  - Details:
-    - `GeometricCA` replaces `UIOrganismField` custom automata
-    - `InverseDesigner` for target layout → rule discovery
-    - `SelfAssembler` / `UIAssembler` for self-assembling UI
-    - `CayleyNavigator` for algebraic structure exploration
-    - amari-automata docs explicitly mention being built for cliffy-alive
+- [ ] Bump amari-flynn 0.17.0 → 0.19.0 (check rand 0.8 compatibility)
+- [ ] Add SMT proof export to invariants
+  - `ImpossibleInvariant::export_smt()` → `precondition_obligation(name, desc, 1.0)`
+  - `RareInvariant::export_smt()` → `hoeffding_obligation(name, samples, epsilon, delta)`
+  - Both return `SmtProofObligation` for `.smt2` files
+  - Add `verify_with_smt()` for Monte Carlo vs SMT cross-verification
+- [ ] Enrich `InvariantTestReport` with statistical bounds
+  - `confidence_interval: Option<(f64, f64)>` field
+  - Use `MonteCarloVerifier::estimate_probability()` → (estimate, lower, upper)
+  - Use `hoeffding_bound(n, epsilon)` for required sample count
+  - Use `confidence_interval(successes, total, confidence)` for CI
 
 ---
 
-## Example Enhancements
+## v0.5.0 — Production Polish
 
-### Document Editor (`examples/document-editor`)
-
-- [ ] **Implement Force Sync button with visible CRDT merge**
-  - Origin: Phase 6 (Examples) bugfix testing
-  - Related: cliffy-protocols CRDT
-  - Issue: Force Sync button only logs to console, doesn't demonstrate CRDT conflict resolution
-  - Fix: Create simulated concurrent edits from remote users, then merge and show resolution visually
-
-- [ ] **Add remote user cursor position updates**
-  - Origin: Phase 6 (Examples) bugfix testing
-  - Issue: Remote user (Alice, Bob, Charlie) cursor positions don't update visually
-  - Fix: Add periodic updates to simulate remote editing activity with visible cursor movement
-
-- [ ] **Show CRDT operation history visualization**
-  - Origin: Phase 6 (Examples) bugfix testing
-  - Issue: Operations panel exists but doesn't clearly show conflict resolution
-  - Fix: Highlight merged operations, show vector clock causality
-
-### Design Tool (`examples/design-tool`)
-
-- [ ] **Review completeness and functionality**
-  - Origin: Phase 6 (Examples) bugfix testing
-  - Issue: Reported as potentially incomplete during testing
-  - Fix: Verify all advertised features work (shape manipulation, undo/redo, etc.)
+- [ ] Implement `initHtml()` integration / export `DOMProjection` from cliffy-wasm
+- [ ] Add TypeScript type definitions for `html.ts` (eliminate `any` casts)
+- [ ] Add cleanup for orphaned subscriptions (WeakRef-based disposal pattern)
+- [ ] Remove `any` types from PureScript Foreign.js (JSDoc types or convert to TS)
+- [ ] Performance profiling of hot paths (subscription propagation, geometric operations)
+- [ ] Audit race conditions in subscription graph
 
 ---
 
-## Documentation Updates (Algebraic TSX)
+## v0.6.0 — API Coherence
 
-These tasks update existing documentation and code snippets to use the new Algebraic TSX patterns.
-
-### Core Documentation
-
-- [x] **Update CLAUDE.md code examples** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4 (Algebraic TSX)
-  - Issue: CLAUDE.md examples show raw `behavior`/`subscribe` usage without Algebraic TSX
-  - Fix: Added Algebraic TSX section with TypeScript and PureScript examples
-
-- [x] **Update getting-started.md with Algebraic TSX** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 7
-  - Issue: Getting started guide may not reflect new UI patterns
-  - Fix: Added Quick Start section with Algebraic TSX examples
-
-- [x] **Update API reference with rendering examples** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 7
-  - Issue: API docs show FRP primitives but not how to render them
-  - Fix: Created comprehensive API reference with FRP primitives and Algebraic TSX rendering
-
-### Code Snippet Updates
-
-- [x] **Audit existing examples for Algebraic TSX** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 6
-  - Issue: Existing examples (whiteboard, etc.) may use older patterns
-  - Decision: Whiteboard example is appropriate as-is because:
-    - Canvas rendering is inherently imperative (not declarative DOM)
-    - Example focuses on geometric strokes and GPU acceleration
-    - Toolbar interactions are minimal and work well with vanilla JS
-  - Future Algebraic TSX examples will be created separately (tsx-counter, tsx-todo)
-
-- [x] **Update README.md quick start** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 7
-  - Issue: Root README may show outdated usage patterns
-  - Fix: Added Quick Start with `npx create-cliffy` and Algebraic TSX examples
-
-- [x] **Add Algebraic TSX section to ROADMAP.md** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4, Phase 7
-  - Issue: ROADMAP mentions Algebraic TSX but details are sparse
-  - Fix: Added Phase 7.0 documenting implementation, design decisions, and relationship to Phase 4
-
-### PureScript-Specific
-
-- [x] **Create cliffy-purescript README** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4
-  - Issue: No README explaining PureScript package usage
-  - Fix: Created comprehensive README with module structure, examples, API comparison
-
-- [x] **Document PureScript FFI patterns** ✅
-  - Origin: Phase 7 (Documentation)
-  - Related: Phase 4
-  - Issue: Foreign.js lacks documentation on how FFI bindings work
-  - Fix: Created docs/purescript-ffi-patterns.md explaining Effect thunks, currying, and implementation structure
+- [ ] Unify TypeScript/PureScript API naming (document intentional differences, fix unintentional ones)
+- [ ] PureScript bindings: decide maintain vs archive
+- [ ] Expand Playwright E2E tests (per-example tests, cross-browser, performance regression)
+- [ ] Example audit — verify all advertised features work (design-tool completeness, etc.)
+- [ ] Update `examples/vite.config.shared.ts` for all template types
+- [ ] Document editor enhancements:
+  - [ ] Wire up Force Sync button with visible CRDT merge
+  - [ ] Add remote user cursor position updates
+  - [ ] Show CRDT operation history visualization
+- [ ] Rewritten documentation (getting-started, API reference, architecture guide)
+- [ ] Add example CI workflow (build all examples, run example-specific tests)
+- [ ] Remove `archive/` — migrate `archive/cliffy-alive` into new cliffy-alive crate as reference, delete the rest
+- [ ] Deprecate and remove dead code paths
 
 ---
 
-## Planned Examples (Phase 6 Completion)
+## Deferred / 2.0
 
-### Phase 6 Planned Applications
-
-From ROADMAP.md Phase 6.3, these example applications need to be built:
-
-| Application | Status | Demonstrates |
-|-------------|--------|--------------|
-| Collaborative Whiteboard | ✅ Exists | Real-time drawing with geometric transforms |
-| Multiplayer Game | ✅ Complete | High-frequency state sync, interpolation |
-| Shared Document Editor | ✅ Complete | CRDT text, presence indicators |
-| Design Tool | ✅ Complete | Complex geometric operations, undo/redo |
-
-#### Multiplayer Game Example
-
-- [x] **Create `examples/multiplayer-game/`** ✅
-  - Demonstrates: High-frequency state sync, geometric interpolation, distributed compute
-  - Features:
-    - Player position as GeometricState
-    - Interpolated movement using .blend() (SLERP/LERP)
-    - Collision detection via geometric distance
-    - Latency compensation with simulated network delay
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
-
-#### Shared Document Editor Example
-
-- [x] **Create `examples/document-editor/`** ✅
-  - Demonstrates: CRDT text, operational transforms, presence
-  - Features:
-    - Text operations as GeometricCRDT entries
-    - Cursor positions as FRP Behaviors
-    - User presence indicators with typing status
-    - Conflict-free concurrent editing with simulated peers
-    - Real-time operation log visualization
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
-
-#### Design Tool Example
-
-- [x] **Create `examples/design-tool/`** ✅
-  - Demonstrates: Complex geometric operations, undo/redo, transform composition
-  - Features:
-    - Shape manipulation via rotors
-    - Undo/redo via history management
-    - Properties panel with real-time binding
-    - Keyboard shortcuts (Delete, Ctrl+Z, Ctrl+Shift+Z)
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
-
-### Algebraic TSX Showcase Examples
-
-These examples specifically demonstrate the Algebraic TSX rendering approach:
-
-#### TypeScript html`` Template Examples
-
-- [x] **Create `examples/tsx-counter/`** ✅
-  - Demonstrates: Basic `html` tagged template usage
-  - Features:
-    - Behavior in text content
-    - Event handlers
-    - Conditional CSS classes
-  - Status: Complete, tested with @cliffy-ga/core@0.1.2
-
-- [x] **Create `examples/tsx-todo/`** ✅
-  - Demonstrates: List rendering, component composition
-  - Features:
-    - Dynamic lists with Behavior<Array>
-    - Nested html`` templates
-    - Form handling with Events
-    - Filter buttons with derived state
-  - Status: Complete, TodoMVC-style implementation
-
-- [x] **Create `examples/tsx-forms/`** ✅
-  - Demonstrates: Form validation, two-way binding patterns
-  - Features:
-    - Input value binding
-    - Validation state as Behavior
-    - Password strength indicator
-    - Uses `wedge()` for combining validations
-  - Status: Complete, demonstrates new GA-inspired API
-
-#### PureScript DSL Examples
-
-- [x] **Create `examples/purescript-counter/`** ✅
-  - Demonstrates: Basic Cliffy.Html DSL usage
-  - Features:
-    - Type-safe element construction
-    - Behavior-reactive content
-    - Event handling with Effect
-  - Status: Complete
-
-- [x] **Create `examples/purescript-todo/`** ✅
-  - Demonstrates: ADTs for state, list rendering
-  - Features:
-    - Todo items as ADT
-    - Pattern matching in render
-    - Type-safe event handling
-  - Status: Complete
-
-### Phase-Specific Showcase Examples
-
-Examples that demonstrate specific phase capabilities:
-
-#### Phase 0: Testing Framework
-
-- [x] **Create `examples/testing-showcase/`** ✅
-  - Demonstrates: cliffy-test geometric invariants
-  - Features:
-    - Interactive test runner with progress visualization
-    - Invariant definitions (rotor normalization, sandwich product)
-    - Manifold constraint testing (unit sphere, positive definite)
-    - Probabilistic tests (rare/impossible patterns from amari-flynn)
-    - Sample point visualization with pass/fail coloring
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
-
-#### Phase 1: Geometric State
-
-- [x] **Create `examples/geometric-transforms/`** ✅
-  - Demonstrates: Explicit geometric operations
-  - Features:
-    - Rotor rotations in XY, XZ, YZ planes
-    - Transform composition (rotation + translation)
-    - .blend() interpolation (SLERP)
-    - GeometricState transformations
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
-
-#### Phase 2: Distributed State
-
-- [x] **Create `examples/crdt-playground/`** ✅
-  - Demonstrates: Geometric CRDT operations
-  - Features:
-    - Multiple simulated peers with independent state
-    - Vector clocks for causal ordering
-    - Concurrent operations and merge visualization
-    - Convergence demonstration with geometric mean
-  - Stack: TypeScript + Vite (simulates cliffy-protocols CRDT)
-  - Status: Complete
-
-#### Phase 3: Synchronization
-
-- [x] **Create `examples/p2p-sync/`** ✅
-  - Demonstrates: WebRTC-style state synchronization
-  - Features:
-    - Simulated peer discovery with mesh topology
-    - Real-time sync with delta visualization
-    - Network partition simulation (click peers to toggle)
-    - Vector clock-based causal ordering
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
-
-#### Phase 5: Edge Computing
-
-- [x] **Create `examples/gpu-benchmark/`** ✅
-  - Demonstrates: WebGPU/WASM performance testing
-  - Features:
-    - WebGPU, SIMD, SharedArrayBuffer detection
-    - Geometric algebra operation benchmarks
-    - Real-time performance metrics (ops/sec)
-    - Visual performance comparison bars
-  - Stack: TypeScript + Vite + @cliffy-ga/core
-  - Status: Complete
+- [ ] Higher-dimensional algebras: PGA Cl(3,0,1) and CGA Cl(4,1,0)
+- [ ] Schubert calculus conflict resolution (Grassmannian intersections, enumerative merge)
+- [ ] AI-composable DSL design
+- [ ] cliffy-alive: Replace custom CA with amari-automata `GeometricCA`
+  - `InverseDesigner` for target layout → rule discovery
+  - `SelfAssembler` / `UIAssembler` for self-assembling UI
+  - `CayleyNavigator` for algebraic structure exploration
 
 ---
 
-## Example Infrastructure
+## Completed
 
-### Shared Setup
+<details>
+<summary>Completed items (click to expand)</summary>
 
-- [ ] **Update `examples/vite.config.shared.ts`**
-  - Add html.ts resolution
-  - Configure for all template types
+### Export/Packaging
+- [x] Export `html.ts` from `cliffy-wasm` package — post-build script copies to pkg/, import via `cliffy-wasm/html`
+- [x] Create main `Cliffy.purs` module — FRP primitive re-exports
+- [x] Wire up PureScript package dependencies — git dependency in `packages.dhall.template`
 
-- [ ] **Create example template generator script**
-  - `scripts/create-example.ts`
-  - Scaffolds new example with correct structure
-  - Options for TS/PS, with/without html template
+### Documentation
+- [x] Document Behavior.map() vs Array.map() distinction
+- [x] Create Algebraic TSX migration guide (docs/migration-guide.md)
+- [x] Update CLAUDE.md code examples with Algebraic TSX
+- [x] Update getting-started.md with Algebraic TSX
+- [x] Create API reference with rendering examples
+- [x] Add Algebraic TSX section to ROADMAP.md
+- [x] Audit existing examples for Algebraic TSX
+- [x] Update README.md quick start with `npx create-cliffy`
+- [x] Create cliffy-purescript README
+- [x] Document PureScript FFI patterns (docs/purescript-ffi-patterns.md)
 
-### Testing Infrastructure
+### Examples
+- [x] Collaborative Whiteboard — real-time drawing with geometric transforms
+- [x] Multiplayer Game — high-frequency state sync, interpolation
+- [x] Shared Document Editor — CRDT text, presence indicators
+- [x] Design Tool — complex geometric operations, undo/redo
+- [x] tsx-counter — basic `html` tagged template usage
+- [x] tsx-todo — list rendering, component composition
+- [x] tsx-forms — form validation, GA-inspired API
+- [x] purescript-counter — Cliffy.Html DSL
+- [x] purescript-todo — ADTs for state, list rendering
+- [x] testing-showcase — cliffy-test geometric invariants
+- [x] geometric-transforms — rotor rotations, composition, slerp
+- [x] crdt-playground — geometric CRDT operations
+- [x] p2p-sync — WebRTC state synchronization
+- [x] gpu-benchmark — WebGPU/WASM performance testing
 
-- [ ] **Expand Playwright E2E tests**
-  - Add tests for each example
-  - Cross-browser verification
-  - Performance regression tests
-
-- [ ] **Add example CI workflow**
-  - Build all examples
-  - Run example-specific tests
-  - Deploy to GitHub Pages for demos
-
----
-
-## Tracking
-
-### Completed Items
-
-- [x] Add note clarifying Behavior.map() vs Array.map() (Phase 7)
-- [x] Create html`` tagged template implementation (Phase 7)
-- [x] Create PureScript Html DSL (Phase 7)
-- [x] Update scaffolding templates to use Algebraic TSX (Phase 7)
-- [x] Create main Cliffy.purs module with FRP primitives (Phase 7)
-- [x] Wire up PureScript package dependencies (Phase 7)
-- [x] Export html.ts from cliffy-wasm package (Phase 7)
-- [x] Update README.md quick start with Algebraic TSX (Phase 7)
-- [x] Update CLAUDE.md code examples (Phase 7)
-- [x] Create cliffy-purescript README (Phase 7)
-- [x] Update getting-started.md with Algebraic TSX (Phase 7)
-- [x] Create API reference with rendering examples (Phase 7)
-- [x] Add Algebraic TSX section to ROADMAP.md (Phase 7)
-- [x] Audit existing examples for Algebraic TSX (Phase 7)
-- [x] Document PureScript FFI patterns (Phase 7)
-- [x] Create Algebraic TSX migration guide (Phase 7)
-- [x] Create geometric-transforms example (Phase 6)
-- [x] Create design-tool example (Phase 6)
-- [x] Create gpu-benchmark example (Phase 6)
-- [x] Create crdt-playground example (Phase 2)
-
-### In Progress
-
-- Phase 9.5: Amari 0.19.0 Upgrade (Foundation Hardening)
-- Phase 7 Documentation continues
-
-### Completed This Sprint
-
-- All distributed examples completed (Phase 2 WASM bindings added):
-  - multiplayer-game - High-frequency state sync, geometric interpolation ✅
-  - document-editor - CRDT text, operational transforms, presence ✅
-  - p2p-sync - WebRTC state synchronization ✅
-  - testing-showcase - cliffy-test geometric invariants ✅
+</details>
 
 ---
 
 ## References
 
-- [ROADMAP.md](./ROADMAP.md) - Full development roadmap
-- [CLAUDE.md](./CLAUDE.md) - Development standards and architecture
-- [examples/README.md](./examples/README.md) - Example documentation
+- [ROADMAP.md](./ROADMAP.md) — Full development roadmap
+- [CLAUDE.md](./CLAUDE.md) — Development standards and architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Vision
 
-Cliffy enables building collaborative applications at Google Docs scale (10,000+ concurrent users) where **distributed systems problems become geometric algebra problems** with closed-form solutions and guaranteed convergence.
+Cliffy is **geometric state management and distributed synchronization for any UI framework**. It enables building collaborative applications at Google Docs scale (10,000+ concurrent users) where **distributed systems problems become geometric algebra problems** with closed-form solutions and guaranteed convergence.
+
+Cliffy is used *inside* existing frameworks (React, Leptos, Yew, vanilla JS), not *instead of* them. It provides the state and synchronization layer while the framework handles rendering.
 
 ### The Core Insight
 
@@ -48,13 +50,13 @@ mount(app, '#app');
 │  (Collaborative Docs, Games, Design Tools, Whiteboards)         │
 └─────────────────────────────────────────────────────────────────┘
                               │
-        ┌─────────────────────┴─────────────────────┐
-        │                                           │
-        ▼                                           ▼
-┌───────────────────────────────┐     ┌───────────────────────────────┐
-│        Algebraic TSX          │     │      Trebek (Mobile)          │
-│  (Web: dataflow → DOM)        │     │  (RN/Lynx: machines → native) │
-└───────────────────────────────┘     └───────────────────────────────┘
+        ┌─────────────────────┼─────────────────────┐
+        │                     │                     │
+        ▼                     ▼                     ▼
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────────┐
+│  Algebraic TSX  │  │ cliffy-tsukoshi │  │  Framework Adapters  │
+│  (html`` → DOM) │  │ (Pure TS path)  │  │ (React, Leptos, Yew) │
+└─────────────────┘  └─────────────────┘  └─────────────────────┘
                               │
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Synchronization Layer                         │
@@ -82,28 +84,35 @@ mount(app, '#app');
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-## Current State
+## Current State (v0.3.0)
 
-### Active Crates
+### Rust Crates
 
 | Crate | Tests | Description |
 |-------|-------|-------------|
-| `cliffy-core` | 79 | FRP primitives (Behavior, Event) with GA3 internally |
-| `cliffy-wasm` | - | WASM bindings + html.ts (Algebraic TSX) |
-| `cliffy-purescript` | - | PureScript bindings with type-safe Html DSL |
-| `cliffy-protocols` | 42 | Distributed state (CRDT, sync, storage) |
-| `cliffy-test` | 25 | Geometric testing framework |
-| `cliffy-gpu` | 18 | WebGPU acceleration (SIMD fallback) |
-| `cliffy-loadtest` | 15 | Scale testing simulator |
+| `cliffy-core` | 85 | FRP primitives, Component trait, dataflow, projections, transforms |
+| `cliffy-protocols` | 42 | CRDT, lattice join, delta sync, consensus, storage |
+| `cliffy-test` | 30 | Geometric invariants, manifold testing, SMT proof export |
+| `cliffy-gpu` | 18 | WebGPU compute + SIMD fallback |
+| `cliffy-loadtest` | 15 | Scale simulation (100–10k peers) |
+| `cliffy-wasm` | 4 | WASM bindings + Algebraic TSX (html tagged template) |
 
-### Scaffolding
+### TypeScript
+
+| Package | Tests | Description |
+|---------|-------|-------------|
+| `cliffy-tsukoshi` | 113 (vitest) | Pure TS geometric state + distributed protocols, React component library |
+
+### Tooling
 
 - `tools/create-cliffy` — CLI to scaffold new projects (`npx create-cliffy`)
+- `cliffy-purescript` — PureScript bindings with type-safe Html DSL
 
-### Archived
+### Experimental / Archived
 
-- `cliffy-alive` — Living UI / cellular automata
+- `cliffy-alive` — Living UI / cellular automata (experimental, on feature branch)
 - `cliffy-typescript` — Deprecated by WASM-first approach
+- Trebek (RN + Lynx) — Shelved; tsukoshi covers mobile/edge as pure TS
 
 ## Development Standards
 
@@ -269,16 +278,12 @@ counter = do
 
 See `ROADMAP.md` for full details. Summary:
 
-| Phase | Focus |
-|-------|-------|
-| **0** | Algebraic Testing (cliffy-test + amari-flynn) |
-| **1** | Geometric State (rotors, versors, projections) |
-| **2** | Distributed State (CRDT revival, lattice join) |
-| **3** | Synchronization (WebRTC, deltas, persistence) |
-| **4** | Algebraic TSX (composable components, dataflow graphs) |
-| **5** | Edge Computing (WebGPU, distributed compute) |
-| **6** | Production (scale testing, docs, examples) |
-| **7** | Native Mobile (Trebek: RN + Lynx middleware) |
+| Version | Focus |
+|---------|-------|
+| **0.4.0** | Typed Algebra — replace raw GA3 with typed Rotor/Vector/Bivector |
+| **0.5.0** | Production Polish — memory leaks, type holes, performance |
+| **0.6.0** | API Coherence — unified naming, docs, E2E tests |
+| **1.0.0** | Stable Release — semver commitment, crates.io + npm |
 
 ## Key Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "amari-core"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +280,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cliffy-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "amari-core",
  "serde",
@@ -269,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cliffy-gpu"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "amari-core",
  "bytemuck",
@@ -284,19 +304,19 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
- "wide",
+ "wide 1.1.1",
 ]
 
 [[package]]
 name = "cliffy-loadtest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "amari-core",
  "cliffy-core",
  "cliffy-protocols",
  "cliffy-test",
  "instant",
- "rand 0.8.5",
+ "rand 0.10.0",
  "rayon",
  "serde",
  "serde_json",
@@ -307,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "cliffy-protocols"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "amari-core",
  "cliffy-core",
@@ -318,13 +338,13 @@ dependencies = [
 
 [[package]]
 name = "cliffy-test"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "amari-core",
  "amari-flynn",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.8.5",
+ "rand 0.10.0",
  "rayon",
  "serde",
  "tokio",
@@ -332,16 +352,17 @@ dependencies = [
 
 [[package]]
 name = "cliffy-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cliffy-core",
  "cliffy-protocols",
  "cliffy-test",
  "console_error_panic_hook",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "getrandom 0.4.1",
  "js-sys",
- "rand 0.8.5",
+ "rand 0.10.0",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -396,26 +417,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -423,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -612,6 +641,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
@@ -730,12 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,21 +806,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1070,6 +1096,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1268,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
+ "chacha20",
  "getrandom 0.4.1",
  "rand_core 0.10.0",
 ]
@@ -1369,6 +1406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,7 +1494,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "paste",
- "wide",
+ "wide 0.7.33",
 ]
 
 [[package]]
@@ -1962,8 +2008,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
- "safe_arch",
+ "safe_arch 0.7.4",
 ]
+
+[[package]]
+name = "wide"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
+dependencies = [
+ "bytemuck",
+ "safe_arch 1.0.0",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -1973,6 +2045,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,9 @@
 
 ## Vision
 
-Build collaborative applications at Google Docs scale (10,000+ concurrent users) where distributed systems problems become geometric algebra problems with closed-form solutions and guaranteed convergence.
+Cliffy is **geometric state management and distributed synchronization for any UI framework**.
+
+It enables building collaborative applications at Google Docs scale (10,000+ concurrent users) where distributed systems problems become geometric algebra problems with closed-form solutions and guaranteed convergence.
 
 ```
 Traditional approach:          Cliffy approach:
@@ -16,2563 +18,278 @@ State reconciliation           State as multivector projections
 ### Core Insight
 
 All state transformations are geometric operations in Clifford algebra:
-- State changes = rotors/versors (geometric transformations)
-- Conflicts = geometric distance from expected manifold
-- Resolution = geometric mean (closed-form, always converges)
-- Composition = geometric product (associative)
+- **State changes** = rotors/versors (geometric transformations)
+- **Conflicts** = geometric distance from expected manifold
+- **Resolution** = geometric mean (closed-form, always converges)
+- **Composition** = geometric product (associative)
 
-## Release Milestones
+### Integration Model
 
-| Version | Phase | Milestone | Status |
-|---------|-------|-----------|--------|
-| **0.1.x** | Phase 7-8 | First Public Release | ✅ Released (v0.1.3) |
-| **0.2.0** | Phase 9 | P2P Sync + Tooling | 🎯 Next Target |
-| **0.3.0** | Phase 10 | Component Library | Planned |
-| **0.4.0** | Phase 11 | Living UI | Planned |
-| **0.5.0** | Phase 12 | Mobile Support | Planned |
+Cliffy is used *inside* existing frameworks, not *instead of* them. It provides the state and synchronization layer while React, Leptos, Yew, or vanilla JS handle rendering:
 
-### v0.1.x (Released)
-- Core FRP primitives (Behavior, Event, combinators)
-- WASM bindings with Algebraic TSX (html tagged template)
-- Distributed state protocols (CRDT, sync, storage)
-- Geometric testing framework
-- GPU acceleration with SIMD fallback
-- 13 example applications deployed to Netlify
-- PureScript bindings with type-safe Html DSL
-- `create-cliffy` scaffolding CLI
+```typescript
+// React component using Cliffy for state
+const Counter = () => {
+  const count = useBehavior(sharedCount); // Cliffy behavior → React state
+  return <button onClick={() => sharedCount.update(n => n + 1)}>{count}</button>;
+};
 
-### Pre-release Phases (0.0.x)
+// Or standalone with Algebraic TSX (no framework)
+const app = html`<button onclick=${() => count.update(n => n + 1)}>${count}</button>`;
+mount(app, '#app');
+```
 
-Phases 0-7 are internal development milestones leading to the first public release:
+---
 
-| Phase | Focus |
-|-------|-------|
-| Phase 0 | Algebraic Testing Framework |
-| Phase 1 | Geometric State Foundation |
-| Phase 2 | Distributed State (CRDT) |
-| Phase 3 | Synchronization Layer |
-| Phase 4 | Algebraic TSX Components |
-| Phase 5 | Edge Computing (WebGPU) |
-| Phase 6 | Production Readiness |
-| Phase 7 | Comprehensive Documentation |
+## Current State — v0.3.0
 
-## Current State
-
-**Current Release: v0.1.3** (`@cliffy-ga/core` on npm)
-
-### Active Crates
+### Rust Crates
 
 | Crate | Tests | Description |
 |-------|-------|-------------|
-| `cliffy-core` | 79 | FRP primitives (Behavior, Event) with GA3 internally |
-| `cliffy-wasm` | 4 | WASM bindings + html.ts (Algebraic TSX) |
-| `cliffy-protocols` | 42 | Distributed state (CRDT, sync, storage, lattice) |
-| `cliffy-test` | 25 | Geometric testing framework (invariants, manifolds) |
-| `cliffy-gpu` | 18 | WebGPU acceleration with SIMD fallback |
-| `cliffy-loadtest` | 15 | Scale testing simulator |
-| `amari-core` | External | Geometric algebra library (dependency) |
+| `cliffy-core` | 85 | FRP primitives, Component trait, dataflow, projections, transforms |
+| `cliffy-protocols` | 42 | CRDT, lattice join, delta sync, consensus, storage |
+| `cliffy-test` | 30 | Geometric invariants, manifold testing, SMT proof export |
+| `cliffy-gpu` | 18 | WebGPU compute + SIMD fallback |
+| `cliffy-loadtest` | 15 | Scale simulation (100–10k peers) |
+| `cliffy-wasm` | 4 | WASM bindings + Algebraic TSX (html tagged template) |
 
-### Archived (to be revived)
+### TypeScript / JavaScript
 
-| Crate | Status | Description |
-|-------|--------|-------------|
-| `cliffy-alive` | 📦 Archived | Living UI / cellular automata (experimental) |
+| Package | Tests | Description |
+|---------|-------|-------------|
+| `cliffy-tsukoshi` | 113 (vitest) | Pure TS geometric state + distributed protocols |
 
-### Deployed Examples (Netlify)
+### Tooling
 
-| Category | Examples |
-|----------|----------|
-| Basics | tsx-counter, tsx-todo, tsx-forms |
-| Tools | whiteboard, design-tool |
-| Distributed | crdt-playground, document-editor, p2p-sync, multiplayer-game |
-| Advanced | geometric-transforms, gpu-benchmark, testing-showcase |
-| Infrastructure | landing page |
+- `tools/create-cliffy` — CLI scaffolding (`npx create-cliffy`)
+- `vite-plugin` — Vite integration for Cliffy projects
+- PureScript bindings (`cliffy-purescript`) with type-safe Html DSL
+- 14 example applications deployed on Netlify
 
-### Development Standards
+---
 
-Cliffy follows the same idioms as other Industrial Algebra projects:
+## Release History
 
-**Idiomatic Rust**
+### v0.1.x — First Public Release
+- Core FRP primitives (Behavior, Event, combinators)
+- WASM bindings with Algebraic TSX
+- Distributed state protocols (CRDT, sync, storage)
+- Geometric testing framework + GPU acceleration
+- 13 example applications, PureScript bindings, `create-cliffy` CLI
+
+### v0.2.0 — P2P Sync + Tooling
+- WebRTC-based peer discovery and synchronization
+- Delta encoding for efficient state transfer
+- Vite plugin and improved scaffolding templates
+- Additional examples (p2p-sync, document-editor, multiplayer-game)
+
+### v0.3.0 — Amari 0.19.0 + Protocols + Hardening
+- Upgraded to Amari 0.19.0 across workspace (typed rotors, vectors, bivectors available)
+- Enhanced cliffy-protocols with improved CRDT and consensus
+- Enabled Dependabot for dependency management
+- Bumped all packages to v0.3.0
+
+---
+
+## Path to 1.0
+
+### v0.4.0 — Typed Algebra
+
+Replace raw `GA3` / `Multivector` usage with Amari 0.19's typed geometric primitives throughout the codebase.
+
+**cliffy-core**
+- [ ] Replace raw GA3 rotation with `Rotor<3,0,0>` via `Rotor::apply()` instead of manual sandwich product
+- [ ] Replace raw GA3 vectors with `Vector<3,0,0>` for position/displacement
+- [ ] `GeometricState.blend()` via `Rotor::slerp()` for correct manifold interpolation
+- [ ] Transform composition via `Rotor::compose()`
+
+**cliffy-protocols**
+- [ ] Type CRDT operations: `GeometricOp::Sandwich` → `Rotor<3,0,0>`, `GeometricOp::Exponential` → `Bivector<3,0,0>`
+- [ ] Type delta encodings: Additive → `Vector<3,0,0>`, Multiplicative → `Rotor<3,0,0>`, Compressed → `Bivector<3,0,0>`
+- [ ] `Rotor::slerp()` for consensus (Fréchet mean on rotor manifold)
+- [ ] `norm_squared()` optimization in hot paths (avoid sqrt in lattice comparisons)
+
+**cliffy-test**
+- [ ] Bump amari-flynn 0.17.0 → 0.19.0
+- [ ] Add SMT proof export to invariants (`ImpossibleInvariant::export_smt()`, `RareInvariant::export_smt()`)
+- [ ] Enrich `InvariantTestReport` with statistical bounds (confidence intervals, Hoeffding bounds)
+
+**cliffy-protocols (storage)**
+- [ ] `VerifiedMultivector` at deserialization boundaries for storage integrity
+
+### v0.5.0 — Production Polish
+
+Eliminate rough edges, memory leaks, and type holes that block real-world usage.
+
+- [ ] WeakRef-based subscription cleanup (prevent memory leaks from orphaned subscriptions)
+- [ ] Wire `initHtml()` / export `DOMProjection` from cliffy-wasm
+- [ ] Eliminate `any` types from `html.ts` (proper generic types)
+- [ ] Remove `any` types from PureScript Foreign.js (add JSDoc types or convert to TS)
+- [ ] `VerifiedMultivector` validation at all deserialization boundaries
+- [ ] Performance profiling and optimization of hot paths
+- [ ] Audit and fix potential race conditions in subscription graph
+
+### v0.6.0 — API Coherence
+
+Consistent, documented, tested API surface across all bindings.
+
+- [ ] Unified API naming across Rust/TypeScript/PureScript
+- [ ] Decision on PureScript bindings: maintain or archive
+- [ ] Rewritten documentation (getting-started, API reference, architecture guide)
+- [ ] Playwright E2E tests for example applications
+- [ ] Deprecate and remove dead code paths
+- [ ] Example audit and cleanup (verify all advertised features work)
+- [ ] Update `examples/vite.config.shared.ts` for all template types
+
+### v1.0.0 — Stable Release
+
+Public API commitment with semver guarantees.
+
+- [ ] Stable `cliffy-core`, `cliffy-protocols`, `cliffy-test` on crates.io
+- [ ] Stable `cliffy-wasm` and `cliffy-tsukoshi` on npm
+- [ ] Comprehensive migration guide from 0.x
+- [ ] API freeze: breaking changes require 2.0
+- [ ] Security audit of distributed protocol layer
+- [ ] Performance benchmarks published
+
+---
+
+## 1.x Ecosystem
+
+Post-1.0 work focused on ecosystem growth and integration.
+
+- **Industrial Algebra MCP integration** — Expose Cliffy state management through MCP for AI-assisted collaborative development
+- **Additional framework adapters** — Svelte, Solid.js adapters alongside existing React/Leptos/Yew support
+- **cliffy-alive stabilization** — Graduate from experimental to optional stable crate (see [Experimental](#experimental-cliffy-alive) below)
+- **Community examples and templates** — Expanded `create-cliffy` templates, community-contributed examples
+- **Enhanced tsukoshi** — React component library, hooks for framework integration, SSR support
+
+---
+
+## 2.0 Vision
+
+Three pillars for the next major version.
+
+### Higher-Dimensional Algebras
+
+Move beyond GA3 Cl(3,0,0) to richer geometric spaces:
+
+**PGA — Projective Geometric Algebra Cl(3,0,1)**
+- Translations become rotors (unified motor algebra)
+- Rigid body transformations as single geometric objects
+- State spaces that naturally represent position + orientation
+
+**CGA — Conformal Geometric Algebra Cl(4,1,0)**
+- Circles, spheres, and inversions as first-class objects
+- Intersection and containment tests via inner product
+- Natural representation for UI layout constraints and physics
+
+Each algebra upgrade is backward-compatible: existing GA3 code continues to work, but new state types can use richer representations.
+
+### Schubert Calculus for Conflict Resolution
+
+Replace heuristic merge strategies with enumerative geometry from Grassmannians. When two peers produce conflicting state:
+
+1. Model each state as a point on a Grassmannian G(k,n)
+2. Compute the Schubert intersection of the two subvarieties
+3. The intersection count determines resolution strategy:
+
+| Intersection | Meaning | Action |
+|-------------|---------|--------|
+| **Finite(0)** | Compatible but unsatisfiable in current algebra | Fallback to higher-dimensional algebra |
+| **Finite(n)** | Exactly n valid resolutions | Enumerate and select (deterministic) |
+| **Empty** | Structurally incompatible | Reject with proof of incompatibility |
+
+This gives **enumerative merge** — provably correct conflict resolution where the number of valid merges is computed, not guessed. Reference: ShaperOS zero-intersection semantics.
+
+### AI-Composable DSL
+
+An API designed to be:
+- **Readable** by humans who don't know geometric algebra
+- **Writable** by AI agents who understand geometric semantics (via MCP)
+- **Verifiable** via amari-flynn contracts + SMT proof obligations
+
+```
+collaborative("doc")
+  .with_state(text, cursor)
+  .sync(peers, Strategy::GeometricMean)
+  .on_conflict(Resolution::Enumerate)
+```
+
+Code reads like a domain-specific language while compiling to efficient geometric operations. AI agents can compose applications by combining verified building blocks.
+
+---
+
+## Experimental: cliffy-alive
+
+Living UI as a concurrent research track, developed on feature branches.
+
+**Purpose**: Testbed for ShaperOS / Yatima Sprites concepts — genetic sub-agents that evolve UI behavior through cellular automata rules expressed as geometric algebra operations.
+
+**Current state**: Archived crate with custom CA implementation.
+
+**Future direction**:
+- Replace custom CA with amari-automata `GeometricCA`
+- `InverseDesigner` for target layout → rule discovery
+- `SelfAssembler` / `UIAssembler` for self-assembling UI components
+- `CayleyNavigator` for algebraic structure exploration
+
+Ships as an optional experimental crate. Not gated on 1.0 milestones — progresses independently as research allows.
+
+---
+
+## Shelved
+
+### Trebek (React Native + Lynx)
+
+Native mobile rendering layer originally planned as Phase 12. **Shelved** because `cliffy-tsukoshi` already covers mobile and edge use cases as pure TypeScript — it runs anywhere JS runs, including React Native.
+
+May revisit as a standalone project if demand for native geometric rendering materializes.
+
+### archive/ Cleanup
+
+The `archive/` directory contains superseded or abandoned crates: `cliffy-components`, `cliffy-dom`, `cliffy-frp`, `cliffy-gpu`, `cliffy-protocols`, `cliffy-typescript`, `cliffy-wasm-old`. These should be removed. The `archive/cliffy-alive` code should be migrated into the new `cliffy-alive` crate as reference material before deletion.
+
+---
+
+## Development Standards
+
+### Idiomatic Rust
 - Leverage the type system fully (enums, traits, generics)
 - Prefer `Result`/`Option` over exceptions/nulls
 - Use iterators and combinators over manual loops
 - Follow Rust API guidelines
 
-**Phantom Types for Type-Level Safety**
+### Phantom Types for Type-Level Safety
 ```rust
-use std::marker::PhantomData;
-
-/// State machine encoded in types - invalid transitions don't compile
 pub struct Document<S: DocumentState> {
     content: String,
     _state: PhantomData<S>,
 }
-
-pub struct Draft;
-pub struct Published;
-pub struct Archived;
-
 impl Document<Draft> {
     pub fn publish(self) -> Document<Published> { ... }
 }
-
-impl Document<Published> {
-    pub fn archive(self) -> Document<Archived> { ... }
-    // Can't call publish() on Published - doesn't exist
-}
 ```
 
-**Contracts via amari-flynn**
-- Use `#[requires]`, `#[ensures]` for function contracts
-- Probabilistic bounds for distributed properties
-- Formal verification where possible (Why3/Creusot integration planned)
-
+### Contracts via amari-flynn
 ```rust
-use amari_flynn::prelude::*;
-
 #[requires(probability > 0.0 && probability < 1.0)]
 #[ensures(result.probability() == probability)]
-pub fn create_rare_event(probability: f64) -> RareEvent<()> {
-    RareEvent::new(probability, "event")
-}
+pub fn create_rare_event(probability: f64) -> RareEvent<()> { ... }
 ```
 
-**Rayon for Parallelism**
-- Use `par_iter()` for data-parallel operations
-- Geometric operations naturally parallelize
-- CRDT merges can be parallelized across partitions
-
+### Rayon for Parallelism
 ```rust
-use rayon::prelude::*;
-
-// Parallel geometric mean computation
 pub fn parallel_geometric_mean(states: &[GA3]) -> GA3 {
-    let sum: GA3 = states
-        .par_iter()
+    states.par_iter()
         .map(|s| s.log())
-        .reduce(GA3::zero, |a, b| &a + &b);
-
-    (sum / states.len() as f64).exp()
-}
-
-// Parallel CRDT merge
-pub fn parallel_merge(nodes: &[GeometricCRDT]) -> GeometricCRDT {
-    nodes
-        .par_iter()
-        .cloned()
-        .reduce_with(|a, b| a.merge(&b))
-        .unwrap_or_default()
-}
-```
-
-**Dependencies Alignment**
-```toml
-[dependencies]
-rayon = "1.10"
-amari-flynn = { path = "../amari/amari-flynn" }  # or version
-```
-
----
-
-### Completed (v0.1.x)
-
-| Component | Status | Description |
-|-----------|--------|-------------|
-| `cliffy-test` | ✅ | Algebraic testing framework (invariants, manifolds, probabilistic) |
-| Geometric State Layer | ✅ | Rotors/versors for state transforms (in cliffy-core) |
-| Lattice Operations | ✅ | Join-semilattice with geometric join (in cliffy-protocols) |
-| Algebraic TSX | ✅ | html tagged template + PureScript DSL (in cliffy-wasm) |
-| WebGPU Acceleration | ✅ | GPU compute with SIMD fallback (in cliffy-gpu) |
-
-### In Progress (v0.2.0)
-
-| Component | Description |
-|-----------|-------------|
-| P2P Sync (WebRTC) | Real WebRTC-based state synchronization (PR #149) |
-| create-cliffy Library Mode | Scaffold component libraries, not just apps |
-
-### Not Yet Built
-
-| Component | Description |
-|-----------|-------------|
-| Component Library | Standard geometric components with theming |
-| Living UI | cliffy-alive integration with new architecture |
-| Trebek Mobile | React Native + Lynx middleware (deferred)
-
----
-
-## Phase 0: Algebraic Testing Framework (cliffy-test)
-
-**Goal**: Tests are geometric invariants. Failures are geometric distances. Test composition uses geometric product.
-
-The testing framework itself must embody the geometric algebra principles - this ensures correctness from the foundation up.
-
-### 0.1 Core Testing Primitives
-
-```rust
-/// Tests as geometric constraints, not boolean assertions
-pub trait GeometricTest {
-    type State: Multivector;
-
-    /// Verify state lies on expected manifold
-    fn verify(&self, state: &Self::State) -> TestResult;
-
-    /// Compose tests via geometric product
-    fn compose(&self, other: &impl GeometricTest) -> ComposedTest;
-}
-
-/// Test results include geometric error information
-pub enum TestResult {
-    Pass,
-    Fail(GeometricError),
-}
-
-pub struct GeometricError {
-    /// Distance from expected manifold
-    distance: f64,
-    /// Gradient pointing toward valid states
-    gradient: GA3,
-    /// Projected correction to nearest valid state
-    correction: GA3,
-}
-```
-
-### 0.2 Invariant Testing
-
-Instead of `assert!(a == b)`, define invariants that must be preserved:
-
-```rust
-invariant! {
-    name: "Rotor preserves magnitude",
-    forall: (v: Vector, r: Rotor),
-    property: magnitude(v) == magnitude(sandwich(r, v, reverse(r)))
-}
-
-invariant! {
-    name: "CRDT merge lies in join lattice",
-    forall: (a: State, b: State),
-    property: merge(a, b) ∈ span(a, b)
-}
-```
-
-### 0.3 Manifold Testing
-
-Valid states form geometric manifolds:
-
-```rust
-/// Define the manifold of valid document states
-pub struct DocumentManifold {
-    dimension: usize,
-    constraints: Vec<ManifoldConstraint>,
-}
-
-impl DocumentManifold {
-    pub fn contains(&self, state: &GA3) -> bool { ... }
-    pub fn distance_to(&self, state: &GA3) -> f64 { ... }
-    pub fn project(&self, state: &GA3) -> GA3 { ... }
-}
-
-#[test]
-fn document_remains_on_manifold() {
-    let initial = create_document();
-    let transformed = apply_operations(initial, ops);
-
-    // Test verifies state lies on manifold
-    assert!(DocumentManifold.contains(&transformed));
-}
-```
-
-### 0.4 Test Composition via Geometric Product
-
-```rust
-// Tests compose like multivectors
-let test_suite = test1 ⊗ test2 ⊗ test3;
-
-// Composition semantics:
-// - All pass → positive scalar result
-// - Failures → non-scalar components indicate failure direction
-// - Partial failures → mixed-grade result
-
-impl GeometricProduct for Test {
-    fn geometric_product(&self, other: &Test) -> ComposedTest {
-        ComposedTest {
-            // Grade 0: both pass
-            // Grade 1: one fails, direction indicates which
-            // Grade 2: interaction failures (both fail together)
-            ...
-        }
-    }
-}
-```
-
-### 0.5 Proof-Carrying Tests
-
-Tests that construct geometric proofs:
-
-```rust
-proof! {
-    name: "All rotors form a group",
-
-    // Identity exists
-    identity: {
-        let e = scalar(1.0);
-        verify sandwich(e, v, e) == v
-    },
-
-    // Closure under composition
-    closure: forall (r1: Rotor, r2: Rotor) => {
-        is_rotor(geometric_product(r1, r2))
-    },
-
-    // Inverse exists
-    inverse: forall (r: Rotor) => {
-        exists reverse(r) where geometric_product(r, reverse(r)) == identity
-    },
-
-    // Associativity (inherited from geometric product)
-    associativity: inherited_from(GeometricProduct)
-}
-```
-
-### 0.6 Cross-Layer Differential Testing
-
-```rust
-/// Verify WASM preserves geometric structure
-homomorphism_test! {
-    name: "WASM preserves geometric structure",
-    morphism: RustImpl -> WASMImpl,
-
-    preserves: [
-        geometric_product,
-        inner_product,
-        outer_product,
-        sandwich_product,
-    ],
-
-    // morphism(a ⊗ b) == morphism(a) ⊗ morphism(b)
-}
-```
-
-### 0.7 Visual Test Debugging
-
-When tests fail, visualize the geometric error:
-
-```rust
-#[visual_test]
-fn state_evolution() {
-    let states = evolve_system(initial, operations);
-
-    // Render 3D visualization of:
-    // - State trajectory
-    // - Expected manifold
-    // - Error distances
-    // - Gradient field
-
-    assert!(states.remain_within(ExpectedManifold.tube(epsilon)));
-}
-```
-
-### 0.8 Probabilistic Contracts (amari-flynn Integration)
-
-Integrate with `amari-flynn` for probabilistic verification. Tests aren't just pass/fail - they have three categories matching the ISO philosophy:
-
-**Three Categories of Test Events:**
-
-| Category | Probability | Meaning |
-|----------|-------------|---------|
-| **Impossible** | P = 0 | Formally proven to never occur |
-| **Rare** | 0 < P << 1 | Statistically bounded failure rate |
-| **Emergent** | P > 0 | Valid but unpredicted behaviors |
-
-```rust
-use amari_flynn::prelude::*;
-use cliffy_test::prelude::*;
-
-// Invariant that must NEVER fail (P = 0)
-// Verified formally or via exhaustive testing
-invariant_impossible! {
-    name: "Rotor preserves magnitude",
-    forall: (v: Vector, r: Rotor),
-    property: |v.magnitude() - sandwich(r, v).magnitude()| < EPSILON
-}
-
-// Property with bounded failure probability (floating point, edge cases)
-invariant_rare! {
-    name: "Geometric mean converges within 100 iterations",
-    probability_bound: 1e-9,
-    samples: 100_000,
-    verify: |states| {
-        let mean = geometric_mean(&states);
-        states.iter().all(|s| mean.distance_to(s) < CONVERGENCE_THRESHOLD)
-    }
-}
-
-// Track emergent behaviors - not failures, just unexpected
-emergent! {
-    name: "Novel CRDT merge trajectories",
-    description: "Merge paths we didn't anticipate but are valid",
-    on_observe: |trajectory| {
-        log::info!("Emergent merge pattern: {:?}", trajectory);
-    }
-}
-```
-
-**Monte Carlo Verification for Distributed Properties:**
-
-```rust
-use amari_flynn::backend::MonteCarloVerifier;
-
-#[probabilistic_test]
-fn crdt_convergence_is_rare_to_fail() {
-    let verifier = MonteCarloVerifier::new(100_000);
-
-    // Verify P(non-convergence) < 1e-6
-    let result = verifier.verify_probability_bound(
-        || {
-            let nodes = spawn_random_nodes(10);
-            let ops = generate_random_operations(1000);
-            apply_concurrent_operations(&nodes, &ops);
-            !all_nodes_converged(&nodes)  // predicate: failure to converge
-        },
-        1e-6  // bound: must fail less than 1 in a million
-    );
-
-    assert_eq!(result, VerificationResult::Verified);
-}
-```
-
-**Statistical Bounds for Performance:**
-
-```rust
-use amari_flynn::statistical::bounds::*;
-
-#[statistical_test]
-fn merge_performance_is_bounded() {
-    let samples = 10_000;
-    let measurements: Vec<Duration> = (0..samples)
-        .map(|_| measure_merge_time())
-        .collect();
-
-    let mean = measurements.iter().sum::<Duration>() / samples;
-    let max_allowed = Duration::from_millis(10);
-
-    // Compute confidence that true mean is within bounds
-    let confidence = compute_confidence(samples, 0.01);
-    assert!(confidence > 0.99);
-    assert!(mean < max_allowed);
-}
-```
-
-**Why This Matters for Cliffy:**
-
-Distributed systems are inherently probabilistic. Network partitions, timing variations, and concurrent operations create scenarios that can't be tested deterministically. By integrating amari-flynn:
-
-1. **Impossible invariants** catch true bugs (violations of geometric laws)
-2. **Rare events** track edge cases with statistical bounds (not flaky tests)
-3. **Emergent behaviors** document valid but unexpected system behaviors
-
-This transforms "flaky tests" into properly categorized probabilistic properties.
-
-**Tasks**:
-- [ ] Add `amari-flynn` as dependency
-- [ ] Create `invariant_impossible!` macro
-- [ ] Create `invariant_rare!` macro with Monte Carlo verification
-- [ ] Create `emergent!` macro for tracking unexpected-but-valid behaviors
-- [ ] Integrate `MonteCarloVerifier` for distributed property testing
-- [ ] Add statistical bounds for performance testing
-- [ ] Create test report format showing probability categories
-- [ ] Document the impossible/rare/emergent philosophy
-
----
-
-**Tasks (Phase 0 Summary)**:
-- [ ] Create `cliffy-test` crate
-- [ ] Implement `GeometricTest` trait
-- [ ] Add `invariant!` macro for property testing
-- [ ] Implement manifold types and distance calculations
-- [ ] Create test composition via geometric product
-- [ ] Add `proof!` macro for geometric proofs
-- [ ] Implement cross-layer homomorphism testing
-- [ ] Create visual debugging for test failures
-- [ ] Integrate amari-flynn for probabilistic contracts
-- [ ] Integrate with `cargo test` runner
-
----
-
-## Phase 1: Geometric State Foundation
-
-**Goal**: State transformations as explicit geometric operations, not hidden implementation detail.
-
-### 1.1 Enrich cliffy-core with Geometric Primitives
-
-Current `Behavior<T>` uses GA3 internally but hides it. We need to expose geometric operations for:
-
-```rust
-// Current (hidden GA)
-let count = behavior(0);
-count.update(|n| n + 1);
-
-// Phase 1 (explicit geometric transforms)
-let state = GeometricState::new(initial);
-state.apply(Rotor::translation(1.0, 0.0, 0.0)); // Translation along e1
-state.apply(Rotor::rotation(angle, plane));     // Rotation in bivector plane
-```
-
-**Tasks**:
-- [ ] Add `GeometricState<T>` type that exposes geometric operations
-- [ ] Implement `Rotor` and `Versor` types for state transformations
-- [ ] Add geometric interpolation (SLERP for smooth transitions)
-- [ ] Create projection functions: multivector → user types
-- [ ] Add tests for geometric operation composition
-
-### 1.2 State as Multivector with Projections
-
-```rust
-/// State lives in geometric space, projects to user types
-pub struct GeometricState {
-    multivector: GA3,
-    projections: Vec<Box<dyn Projection>>,
-}
-
-pub trait Projection {
-    type Output;
-    fn project(&self, mv: &GA3) -> Self::Output;
-}
-
-// Example: Counter as scalar projection
-impl Projection for CounterProjection {
-    type Output = i32;
-    fn project(&self, mv: &GA3) -> i32 {
-        mv.scalar() as i32
-    }
-}
-```
-
-**Tasks**:
-- [ ] Define `Projection` trait
-- [ ] Implement common projections (scalar, vector, position, color)
-- [ ] Add reactive projections that auto-update
-- [ ] Create derive macro for custom projections
-
-### 1.3 WASM Bindings for Geometric Operations
-
-Expose geometric primitives to JavaScript:
-
-```javascript
-import { GeometricState, Rotor } from '@cliffy/core';
-
-const state = new GeometricState(initial);
-
-// Apply geometric transformation
-state.apply(Rotor.translation(1, 0, 0));
-
-// Subscribe to projected values
-state.project('counter').subscribe(n => {
-    console.log('Count:', n);
-});
-```
-
-**Tasks**:
-- [ ] Add `GeometricState` to cliffy-wasm
-- [ ] Expose `Rotor` and `Versor` constructors
-- [ ] Add projection subscription API
-- [ ] Create TypeScript type definitions
-
----
-
-## Phase 2: Distributed State (CRDT Revival)
-
-**Goal**: Revive and modernize cliffy-protocols for lattice-based distributed state.
-
-### 2.1 Migrate cliffy-protocols to Current API
-
-The archived `cliffy-protocols` already has:
-- `GeometricCRDT` with vector clocks
-- Geometric operations (product, addition, sandwich, exponential)
-- Merge with causal ordering
-- `geometric_mean` for conflict resolution
-
-**Tasks**:
-- [ ] Move cliffy-protocols back to workspace
-- [ ] Update to amari-core 0.17+ API
-- [ ] Fix compilation errors
-- [ ] Add comprehensive tests
-- [ ] Document the geometric CRDT model
-
-### 2.2 Lattice-Based Conflict Resolution
-
-Implement join-semilattice operations with geometric algebra:
-
-```rust
-pub trait GeometricLattice {
-    /// Lattice join - always converges, no coordination needed
-    fn join(&self, other: &Self) -> Self;
-
-    /// Check if this state dominates another
-    fn dominates(&self, other: &Self) -> bool;
-
-    /// Compute distance from lattice manifold
-    fn divergence(&self, other: &Self) -> f64;
-}
-
-impl GeometricLattice for GA3 {
-    fn join(&self, other: &GA3) -> GA3 {
-        // Geometric mean - always converges
-        geometric_mean(&[self.clone(), other.clone()])
-    }
-
-    fn dominates(&self, other: &GA3) -> bool {
-        self.magnitude() >= other.magnitude()
-    }
-
-    fn divergence(&self, other: &GA3) -> f64 {
-        (self - other).magnitude()
-    }
-}
-```
-
-**Tasks**:
-- [ ] Define `GeometricLattice` trait
-- [ ] Implement for GA3 multivectors
-- [ ] Add lattice property tests (idempotent, commutative, associative)
-- [ ] Create specialized lattices (counter, set, register, sequence)
-- [ ] Benchmark convergence under concurrent operations
-
-### 2.3 Operation-Based CRDT with Geometric Transforms
-
-```rust
-/// Operations are geometric transformations
-pub enum GeometricOp {
-    /// Translation: move state along an axis
-    Translate { axis: Vector3, distance: f64 },
-
-    /// Rotation: rotate state in a plane
-    Rotate { plane: Bivector, angle: f64 },
-
-    /// Scale: uniform or non-uniform scaling
-    Scale { factors: Vector3 },
-
-    /// Reflection: reflect across a plane
-    Reflect { plane: Bivector },
-
-    /// Arbitrary versor transformation
-    Versor { versor: GA3 },
-}
-
-impl GeometricOp {
-    /// Convert to rotor/versor for application
-    pub fn to_versor(&self) -> GA3 { ... }
-
-    /// Compose operations via geometric product
-    pub fn compose(&self, other: &GeometricOp) -> GeometricOp { ... }
-}
-```
-
-**Tasks**:
-- [ ] Define `GeometricOp` enum
-- [ ] Implement conversion to versors
-- [ ] Add operation composition
-- [ ] Create operation log with causal ordering
-- [ ] Implement operation-based merge
-
----
-
-## Phase 3: Synchronization Layer
-
-**Goal**: P2P synchronization with WebRTC and efficient state deltas.
-
-### 3.1 State Delta Computation
-
-```rust
-/// Compute minimal delta between states
-pub fn compute_delta(from: &GA3, to: &GA3) -> GA3 {
-    // The versor that transforms 'from' into 'to'
-    // to = delta * from * delta^(-1)  (sandwich product)
-    // Solve for delta
-    ...
-}
-
-/// Apply delta to catch up
-pub fn apply_delta(state: &mut GA3, delta: &GA3) {
-    let rev = delta.reverse();
-    *state = delta.geometric_product(state).geometric_product(&rev);
-}
-```
-
-**Tasks**:
-- [ ] Implement delta computation
-- [ ] Add delta compression (log representation)
-- [ ] Create delta batching for efficiency
-- [ ] Benchmark delta sizes vs full state
-
-### 3.2 WebRTC Sync Protocol
-
-```javascript
-// JavaScript API
-const doc = new CollaborativeDocument(initialState);
-
-// Connect to peers
-doc.connect(signalingServer);
-
-// Local changes automatically sync
-doc.state.apply(Rotor.translation(1, 0, 0));
-
-// Remote changes automatically merge
-doc.onSync((delta, peerId) => {
-    console.log(`Synced with ${peerId}`);
-});
-```
-
-**Tasks**:
-- [ ] Design sync protocol message format
-- [ ] Implement WebRTC data channel wrapper
-- [ ] Add signaling server integration
-- [ ] Create peer discovery mechanism
-- [ ] Handle network partitions gracefully
-
-### 3.3 Persistence Layer
-
-```rust
-/// Persist geometric state with operation history
-pub trait GeometricStore {
-    fn save_snapshot(&mut self, state: &GA3, clock: &VectorClock);
-    fn load_snapshot(&self) -> Option<(GA3, VectorClock)>;
-    fn append_operation(&mut self, op: &GeometricOp);
-    fn replay_from(&self, clock: &VectorClock) -> Vec<GeometricOp>;
-}
-```
-
-**Tasks**:
-- [ ] Define storage trait
-- [ ] Implement IndexedDB backend for browser
-- [ ] Add operation log with compaction
-- [ ] Create snapshot + incremental strategy
-
----
-
-## Phase 4: Algebraic TSX
-
-**Goal**: TSX as geometric dataflow graph specification, not virtual DOM. Components compose naturally via geometric product.
-
-### 4.0 Composable Component Model
-
-Components are the primary abstraction. They must feel familiar to React/Vue/Svelte developers while being geometrically grounded.
-
-```tsx
-// Familiar component syntax
-function Counter() {
-    const count = useGeometricState(0);
-
-    return (
-        <div>
-            <span>{count}</span>
-            <button onClick={() => count.translate(1)}>+</button>
-        </div>
-    );
-}
-
-// Composition works as expected
-function App() {
-    return (
-        <div>
-            <Counter />
-            <Counter />
-            <TodoList />
-        </div>
-    );
-}
-```
-
-**Component = Geometric Morphism**
-
-Under the hood, each component is a morphism from geometric state to DOM:
-
-```
-Component: GeometricState → DOM
-Composition: (A → B) ∘ (B → C) = (A → C)
-```
-
-```rust
-pub trait Component {
-    /// Component's local geometric state
-    type State: Multivector;
-
-    /// Project state to renderable output
-    fn render(&self, state: &Self::State) -> Element;
-
-    /// Compose with child components
-    fn compose<C: Component>(self, child: C) -> ComposedComponent<Self, C>;
-}
-
-/// Components compose via geometric product of their state spaces
-impl<A: Component, B: Component> Component for ComposedComponent<A, B> {
-    type State = GeometricProduct<A::State, B::State>;
-
-    fn render(&self, state: &Self::State) -> Element {
-        // Project combined state to both components
-        let (a_state, b_state) = state.decompose();
-        Element::compose(
-            self.a.render(&a_state),
-            self.b.render(&b_state)
-        )
-    }
-}
-```
-
-**Hooks as Geometric Projections**
-
-```tsx
-// Familiar hooks API
-function useGeometricState<T>(initial: T): GeometricBehavior<T>;
-function useProjection<T, U>(state: GeometricState, proj: Projection<T, U>): U;
-function useTransform(state: GeometricState, transform: Rotor): void;
-
-// Example usage
-function ColorPicker() {
-    const color = useGeometricState({ h: 0, s: 100, l: 50 });
-
-    // Derive values via projection
-    const hue = useProjection(color, mv => mv.grade(1).component(0));
-    const saturation = useProjection(color, mv => mv.grade(1).component(1));
-
-    return (
-        <div style={{ background: color.toCSS() }}>
-            <Slider value={hue} onChange={h => color.rotateIn(e12, h)} />
-            <Slider value={saturation} onChange={s => color.scaleAlong(e2, s)} />
-        </div>
-    );
-}
-```
-
-**Props as Geometric Constraints**
-
-```tsx
-interface ButtonProps {
-    // Props constrain the component's geometric state space
-    disabled?: Behavior<boolean>;
-    onClick?: Event<void>;
-    children?: Element;
-}
-
-function Button({ disabled, onClick, children }: ButtonProps) {
-    // Props flow into component's geometric state
-    const state = useGeometricState({ pressed: false });
-
-    // Conditional rendering via geometric projection
-    const opacity = useProjection(
-        combine(state, disabled),
-        (s, d) => d ? 0.5 : 1.0
-    );
-
-    return (
-        <button
-            style={{ opacity }}
-            onClick={when(not(disabled), onClick)}
-        >
-            {children}
-        </button>
-    );
-}
-```
-
-**Tasks**:
-- [ ] Design component trait/interface
-- [ ] Implement hooks API (`useGeometricState`, `useProjection`, etc.)
-- [ ] Create component composition via geometric product
-- [ ] Add props as geometric constraints
-- [ ] Ensure familiar JSX/TSX syntax works
-- [ ] Support children composition
-- [ ] Add component lifecycle (mount, unmount) as geometric events
-
-### 4.1 Dataflow Graph Model
-
-```
-TSX Expression                    Geometric Dataflow
-──────────────                    ──────────────────
-<div>{count$}</div>       →       Projection node: state → DOM text
-<div style={style$}>      →       Projection node: state → CSS
-<button onClick={click$}> →       Event source: DOM → state transform
-```
-
-**Tasks**:
-- [ ] Define dataflow graph IR
-- [ ] Create graph node types (source, projection, transform, sink)
-- [ ] Implement graph optimization passes
-- [ ] Add cycle detection and resolution
-
-### 4.2 Compile-Time Graph Generation
-
-```rust
-// Build-time: TSX → Graph
-#[algebraic_tsx]
-fn Counter() -> Graph {
-    let count = GeometricState::new(0);
-
-    tsx! {
-        <div>
-            <span>{count.project(scalar)}</span>
-            <button onClick={count.translate(1, 0, 0)}>+</button>
-        </div>
-    }
-}
-```
-
-**Tasks**:
-- [ ] Create proc-macro for algebraic TSX
-- [ ] Generate optimized dataflow graphs
-- [ ] Emit efficient WASM code
-- [ ] Add source maps for debugging
-
-### 4.3 Direct DOM Projection
-
-No virtual DOM - project directly from geometric state to DOM:
-
-```rust
-/// Direct projection from multivector to DOM
-pub struct DOMProjection {
-    element: web_sys::Element,
-    projection: Box<dyn Fn(&GA3) -> DOMUpdate>,
-}
-
-impl DOMProjection {
-    fn update(&self, state: &GA3) {
-        match (self.projection)(state) {
-            DOMUpdate::Text(s) => self.element.set_text_content(Some(&s)),
-            DOMUpdate::Style(k, v) => self.element.style().set_property(&k, &v),
-            DOMUpdate::Attribute(k, v) => self.element.set_attribute(&k, &v),
-        }
-    }
-}
-```
-
-**Tasks**:
-- [ ] Implement `DOMProjection` type
-- [ ] Create efficient batch updates
-- [ ] Add animation frame scheduling
-- [ ] Benchmark vs virtual DOM approaches
-
----
-
-## Phase 5: Edge Computing
-
-**Goal**: Every browser is a compute node with WebGPU acceleration.
-
-### 5.1 WebGPU Geometric Operations
-
-```rust
-/// GPU-accelerated geometric algebra
-pub struct GPUMultivector {
-    buffer: wgpu::Buffer,
-    pipeline: wgpu::ComputePipeline,
-}
-
-impl GPUMultivector {
-    /// Batch geometric product on GPU
-    pub async fn batch_product(&self, others: &[GA3]) -> Vec<GA3> {
-        // Run compute shader
-        ...
-    }
-}
-```
-
-**Tasks**:
-- [ ] Create WebGPU compute shaders for GA operations
-- [ ] Implement GPU buffer management
-- [ ] Add automatic CPU/GPU dispatch based on batch size
-- [ ] Benchmark GPU vs CPU for various workloads
-
-### 5.2 Distributed Compute
-
-```javascript
-// Each browser contributes compute
-const cluster = new ComputeCluster();
-
-// Share geometric computation across peers
-const result = await cluster.compute(
-    operations,  // Array of geometric operations
-    strategy: 'distribute'  // or 'replicate' for fault tolerance
-);
-```
-
-**Tasks**:
-- [ ] Design work distribution protocol
-- [ ] Implement task scheduling
-- [ ] Add fault tolerance (replication, retry)
-- [ ] Create load balancing algorithm
-
-### 5.3 Performance Optimization
-
-**Tasks**:
-- [ ] Profile critical paths
-- [ ] Implement SIMD operations in Rust
-- [ ] Add operation batching
-- [ ] Create performance regression tests
-- [ ] Target: 60fps with 1000+ active behaviors
-
-### 5.4 Benchmark Suite
-
-Create comprehensive benchmarks to demonstrate GPU acceleration benefits:
-
-```rust
-/// Benchmark framework for comparing compute backends
-pub struct BenchmarkSuite {
-    scenarios: Vec<BenchmarkScenario>,
-    backends: Vec<ComputeBackend>,
-}
-
-pub enum ComputeBackend {
-    CpuSingleThread,
-    CpuSimd,          // SIMD-optimized CPU
-    CpuParallel,      // Rayon parallel
-    WebGpu,           // GPU compute shaders
-    Distributed,      // Multi-peer distributed
-}
-
-pub struct BenchmarkScenario {
-    name: String,
-    operation_count: usize,
-    state_complexity: StateComplexity,
-}
-```
-
-**Benchmark Scenarios**:
-
-| Scenario | Description | Key Metric |
-|----------|-------------|------------|
-| Geometric Product Batch | 10K-1M multivector products | ops/sec |
-| CRDT Merge Storm | 1K concurrent operations from 100 peers | convergence time |
-| State Sync Flood | High-frequency updates to 10K behaviors | latency p50/p99 |
-| Distributed Compute | Geometric mean across 50 peers | speedup factor |
-| Animation Frame | 1000 interpolating objects at 60fps | frame budget % |
-
-**Tasks**:
-- [ ] Create `cliffy-bench` crate with benchmark harness
-- [ ] Implement CPU baseline benchmarks (single-thread, SIMD, parallel)
-- [ ] Add WebGPU benchmarks with automatic fallback detection
-- [ ] Create distributed compute benchmarks
-- [ ] Generate comparison reports (tables, charts)
-- [ ] Add CI integration for performance regression tracking
-- [ ] Document when GPU acceleration provides benefit (batch size thresholds)
-
----
-
-## Phase 6: Production Readiness
-
-**Goal**: Ready for production collaborative applications.
-
-### 6.1 Scale Testing
-
-**Tasks**:
-- [ ] Create load testing framework
-- [ ] Test with 100, 1000, 10000 simulated users
-- [ ] Measure convergence time under load
-- [ ] Identify and fix bottlenecks
-
-### 6.2 Developer Experience
-
-**Tasks**:
-- [ ] Create comprehensive documentation
-- [ ] Build interactive tutorials
-- [ ] Add debugging tools (state inspector, operation log viewer)
-- [ ] Create migration guides from React/Redux
-
-### 6.3 Example Applications
-
-| Application | Demonstrates |
-|-------------|--------------|
-| Collaborative Whiteboard | Real-time drawing with geometric transforms |
-| Multiplayer Game | High-frequency state sync, interpolation |
-| Shared Document Editor | CRDT text, presence indicators |
-| Design Tool | Complex geometric operations, undo/redo |
-
-**Tasks**:
-- [ ] Build whiteboard example
-- [ ] Build multiplayer game example
-- [ ] Build document editor example
-- [ ] Build design tool example
-
-### 6.4 Performance Benchmark Demos
-
-Each example application should include visible performance comparisons showing GPU/edge computing benefits:
-
-**Benchmark Display Component**:
-```typescript
-// Embedded benchmark UI showing real-time performance
-<BenchmarkPanel>
-  <MetricCard
-    label="Geometric Operations"
-    cpu={cpuOpsPerSec}
-    gpu={gpuOpsPerSec}
-    speedup={gpuOpsPerSec / cpuOpsPerSec}
-  />
-  <MetricCard
-    label="CRDT Merge Time"
-    cpu={cpuMergeMs}
-    gpu={gpuMergeMs}
-  />
-  <MetricCard
-    label="Sync Latency (p99)"
-    local={localLatency}
-    distributed={distributedLatency}
-  />
-</BenchmarkPanel>
-```
-
-**Per-Application Benchmarks**:
-
-| Application | Key Benchmarks |
-|-------------|----------------|
-| Collaborative Whiteboard | Stroke rendering (CPU vs GPU), multi-user sync latency |
-| Multiplayer Game | Physics updates/sec, state interpolation frame time |
-| Document Editor | CRDT merge throughput, conflict resolution time |
-| Design Tool | Transform batch operations, undo stack geometric diff |
-
-**Benchmark Demo Features**:
-- Toggle between CPU/GPU backends at runtime
-- Real-time metrics overlay
-- "Stress test" mode to push operation counts
-- Export benchmark results as JSON/CSV
-
-**Tasks**:
-- [ ] Create `BenchmarkPanel` component for embedding in examples
-- [ ] Add CPU/GPU toggle with live switching
-- [ ] Implement real-time metrics collection and display
-- [ ] Add stress test mode to each example
-- [ ] Create benchmark comparison visualizations (bar charts, speedup graphs)
-- [ ] Document observed speedups in different scenarios
-- [ ] Add "Why is GPU faster?" explanatory tooltips
-
----
-
-## Phase 7: Comprehensive Documentation
-
-**Goal**: Production-quality documentation that makes Cliffy accessible to developers at all levels.
-
-### 7.0 Algebraic TSX Implementation (Completed)
-
-Phase 7 implemented a practical Algebraic TSX system for immediate use, providing a simpler path to reactive UI while the full Phase 4 dataflow graph system is developed.
-
-**What Was Built:**
-
-| Component | Description |
-|-----------|-------------|
-| `html.ts` | TypeScript tagged template for reactive DOM |
-| `Cliffy.Html` | PureScript type-safe Html DSL |
-| `create-cliffy` | CLI scaffolding tool with templates |
-
-**TypeScript: html Tagged Template**
-
-The `html` tagged template creates reactive DOM that automatically updates when Behaviors change:
-
-```typescript
-import { behavior } from 'cliffy-wasm';
-import { html, mount } from 'cliffy-wasm/html';
-
-const count = behavior(0);
-
-// Behaviors in templates automatically update the DOM
-const app = html`
-  <div class="counter">
-    <h1>Count: ${count}</h1>
-    <button onclick=${() => count.update(n => n + 1)}>+</button>
-  </div>
-`;
-
-mount(app, '#app');
-```
-
-**Key Design Decisions:**
-
-1. **No virtual DOM** — Direct DOM manipulation via subscriptions
-2. **Behavior-aware interpolation** — `${behavior}` creates reactive text nodes
-3. **Event handlers as functions** — `onclick=${fn}` attaches native handlers
-4. **Minimal overhead** — Just 100 lines of TypeScript
-
-**PureScript: Type-Safe Html DSL**
-
-The `Cliffy.Html` module provides compile-time guarantees:
-
-```purescript
-import Cliffy (behavior, update)
-import Cliffy.Html (div, button, text, behaviorText, mount)
-import Cliffy.Html.Events (onClick)
-
-counter :: Effect Html
-counter = do
-  count <- behavior 0
-  pure $ div []
-    [ text "Count: "
-    , behaviorText count
-    , button [ onClick \_ -> update (_ + 1) count ] [ text "+" ]
-    ]
-```
-
-**Key Design Decisions:**
-
-1. **Curried API** — Behavior as last argument enables point-free style
-2. **Type-safe attributes** — Wrong attribute on wrong element won't compile
-3. **Effect-based events** — Event handlers return `Effect Unit`
-4. **FFI bridge** — Clean separation between PureScript types and JS runtime
-
-**Scaffolding Tool**
-
-`create-cliffy` provides project templates:
-
-```bash
-npx create-cliffy my-app                        # TypeScript + Vite (default)
-npx create-cliffy my-app --template bun         # Bun runtime
-npx create-cliffy my-app --template purescript  # PureScript + DSL
-```
-
-**Relationship to Phase 4:**
-
-| Current (Phase 7) | Future (Phase 4) |
-|-------------------|------------------|
-| Runtime template parsing | Compile-time graph generation |
-| DOM manipulation | Dataflow graph → DOM |
-| Manual subscriptions | Automatic dependency tracking |
-| Familiar HTML syntax | TSX macros in Rust |
-
-The Phase 7 implementation provides a usable API today. Phase 4 will add compile-time optimization and the full dataflow graph model.
-
-### 7.1 API Reference Documentation
-
-Complete rustdoc coverage for all public APIs:
-
-```rust
-/// Comprehensive doc coverage with examples
-/// - Every public type documented
-/// - Every public function with usage examples
-/// - Error conditions documented
-/// - Performance characteristics noted
-```
-
-**Tasks**:
-- [ ] Full rustdoc coverage for cliffy-core
-- [ ] Full rustdoc coverage for cliffy-wasm
-- [ ] Full rustdoc coverage for cliffy-protocols
-- [ ] Full rustdoc coverage for cliffy-test
-- [ ] Generate and publish docs to docs.rs or custom site
-
-### 7.2 Conceptual Guides
-
-| Guide | Audience | Content |
-|-------|----------|---------|
-| Getting Started | New users | Installation, first app, basic concepts |
-| Geometric Algebra Primer | Curious developers | Intuition for GA without heavy math |
-| FRP with Cliffy | React/Vue developers | Behaviors, Events, and reactive patterns |
-| Distributed State | Backend developers | CRDTs, synchronization, convergence |
-| Algebraic TSX | Frontend developers | Components, dataflow graphs, DOM projection |
-| Testing with cliffy-test | All developers | Geometric invariants, probabilistic tests |
-
-**Tasks**:
-- [ ] Write "Getting Started" guide with step-by-step tutorial
-- [ ] Write "Geometric Algebra Primer" with visual explanations
-- [ ] Write "FRP with Cliffy" migration guide from React hooks
-- [ ] Write "Distributed State" guide with convergence proofs
-- [ ] Write "Algebraic TSX" component authoring guide
-- [ ] Write "Testing" guide with invariant examples
-
-### 7.3 Interactive Tutorials
-
-Browser-based learning experiences:
-
-```
-Tutorial 1: Build a Counter
-─────────────────────────────
-Step 1: Create a Behavior
-Step 2: Add transformations
-Step 3: Project to DOM
-Step 4: Add event handling
-[Interactive code editor with live preview]
-```
-
-**Tasks**:
-- [ ] Create tutorial infrastructure (embedded WASM playground)
-- [ ] Write "Counter" tutorial (fundamental concepts)
-- [ ] Write "Todo List" tutorial (lists, composition)
-- [ ] Write "Collaborative Whiteboard" tutorial (distributed state)
-- [ ] Write "Animation" tutorial (geometric interpolation)
-
-### 7.4 Architecture Documentation
-
-Deep dives into Cliffy's design:
-
-- **Why Geometric Algebra?** - Mathematical foundations and benefits
-- **Dataflow vs Virtual DOM** - Performance and correctness tradeoffs
-- **CRDT Design** - How geometric mean enables coordination-free merging
-- **WASM Architecture** - Rust/JS boundary design decisions
-
-**Tasks**:
-- [ ] Write architecture decision records (ADRs)
-- [ ] Create system diagrams with Mermaid
-- [ ] Document performance characteristics
-- [ ] Write troubleshooting guide
-
-### 7.5 Developer Tools Documentation
-
-- State inspector usage
-- Dataflow graph visualizer
-- Performance profiler
-- Debug logging configuration
-
-**Tasks**:
-- [ ] Document devtools installation
-- [ ] Write devtools usage guide
-- [ ] Create video walkthroughs
-
-### 7.6 IDE and Editor Support
-
-Provide first-class IDE support for Algebraic TSX (`html` tagged templates):
-
-**Supported Editors:**
-
-| Editor | Approach | Features |
-|--------|----------|----------|
-| VSCode | Extension or lit-plugin | Syntax highlighting, completion, type checking |
-| Neovim | Treesitter + LSP | HTML injection in template strings |
-| Zed | Tree-sitter grammar | Native syntax highlighting |
-
-**VSCode Support:**
-```json
-// .vscode/settings.json
-{
-  "lit-plugin.templateTags": ["html"],
-  "html.customData": ["./cliffy-html.json"]
-}
-```
-
-The good news is ATSX uses the same `html` tagged template syntax as lit-html, so existing tooling can be leveraged:
-- **lit-plugin** VSCode extension recognizes `html` template tags
-- **nvim-treesitter** with lit grammar provides HTML injection
-- **tree-sitter-typescript** can be extended for template string injection
-
-**Custom ATSX Language Server (future):**
-```typescript
-// Features to provide:
-// - Completion for HTML elements and attributes
-// - Type checking for ${behavior} interpolations
-// - Validation that Behavior<T> types match attribute expectations
-// - Go-to-definition for event handlers
-// - Hover info showing Behavior types
-```
-
-**Tasks**:
-- [ ] Test lit-plugin with ATSX templates (may work out of box)
-- [ ] Document VSCode setup with lit-plugin
-- [ ] Document Neovim setup with nvim-treesitter
-- [ ] Document Zed configuration
-- [ ] Create `cliffy-vscode` extension if lit-plugin insufficient
-- [ ] Add ATSX-specific TypeScript language service plugin (for type-aware completion)
-- [ ] Create custom tree-sitter grammar for ATSX (if needed)
-- [ ] Document IDE setup in getting-started guide
-
----
-
-## Phase 8: Multi-Language Demo Examples → v0.1.0
-
-**Goal**: Showcase Cliffy across TypeScript, JavaScript, PureScript, and CoffeeScript to demonstrate language flexibility.
-
-**🎯 Milestone: First Public Release (v0.1.0)**
-
-### 8.1 TypeScript Examples ✅
-
-Modern TypeScript with full type safety:
-
-```typescript
-// examples/tsx-counter/src/main.ts
-import init, { behavior } from '@cliffy-ga/core';
-import { html, mount } from '@cliffy-ga/core/html';
-
-await init();
-
-const count = behavior(0);
-
-const app = html`
-  <div class="counter">
-    <h1>Count: ${count}</h1>
-    <button onclick=${() => count.update(n => n + 1)}>+</button>
-  </div>
-`;
-
-mount(app, '#app');
-```
-
-**Examples** (all deployed to Netlify):
-- [x] `tsx-counter` - Basic counter with Algebraic TSX
-- [x] `tsx-todo` - TodoMVC with full typing
-- [x] `tsx-forms` - Form validation with algebraic constraints
-- [x] `whiteboard` - Real-time drawing with geometric transforms
-- [x] `design-tool` - Complex geometric operations, undo/redo
-- [x] `document-editor` - CRDT text, presence indicators
-- [x] `multiplayer-game` - High-frequency state sync, interpolation
-- [x] `crdt-playground` - Geometric CRDT operations
-- [x] `p2p-sync` - Simulated peer synchronization
-- [x] `geometric-transforms` - Rotor rotations, transform composition
-- [x] `gpu-benchmark` - WebGPU/SIMD performance testing
-- [x] `testing-showcase` - cliffy-test geometric invariants
-
-### 8.2 JavaScript Examples (Deferred)
-
-JavaScript examples deferred to v0.2.0. TypeScript examples work without types for JS users.
-
-**Planned for v0.2.0**:
-- [ ] `js-counter` - Minimal counter
-- [ ] `js-cdn` - CDN-only usage (no bundler)
-
-### 8.3 PureScript Examples ✅
-
-Functional programming with algebraic precision:
-
-```purescript
--- examples/purescript-counter/src/Main.purs
-module Main where
-
-import Cliffy (behavior, update)
-import Cliffy.Html (div, button, text, behaviorText, mount)
-import Cliffy.Html.Events (onClick)
-
-main :: Effect Unit
-main = do
-  count <- behavior 0
-
-  let app = div []
-        [ text "Count: "
-        , behaviorText count
-        , button [ onClick \_ -> update (_ + 1) count ] [ text "+" ]
-        ]
-
-  mount app "#app"
-```
-
-**Examples** (require spago toolchain):
-- [x] `purescript-counter` - Counter with pure functional style
-- [x] `purescript-todo` - TodoMVC with ADTs for state
-
-### 8.4 CoffeeScript Examples (Deferred)
-
-CoffeeScript examples deferred to v0.2.0. Lower priority given TypeScript adoption.
-
-### 8.5 Cross-Language Comparison
-
-Side-by-side comparisons showing the same app in all four languages:
-
-| Feature | TypeScript | JavaScript | PureScript | CoffeeScript |
-|---------|------------|------------|------------|--------------|
-| Type Safety | Full | Runtime | Full + ADTs | Runtime |
-| Bundle Size | Medium | Small | Medium | Small |
-| Learning Curve | Low | Lowest | Higher | Low |
-| IDE Support | Excellent | Good | Good | Fair |
-
-**Tasks**:
-- [ ] Create unified example structure
-- [ ] Write cross-language comparison guide
-- [ ] Add language-specific best practices
-- [ ] Create "Choose Your Language" guide
-
-### 8.6 Build Infrastructure
-
-Each example should be self-contained and runnable:
-
-```bash
-# All examples follow same pattern
-cd examples/ts-counter
-npm install
-npm run dev    # Development server
-npm run build  # Production build
-```
-
-**Tasks**:
-- [ ] Create example template generator
-- [ ] Add CI testing for all examples
-- [ ] Ensure examples work with latest Cliffy
-- [ ] Add example showcases to documentation site
-
----
-
-## Phase 9: P2P Sync Polish + Tooling → v0.2.0
-
-**Goal**: Complete the WebRTC P2P synchronization implementation and enhance the create-cliffy scaffolding tool.
-
-**🎯 Milestone: P2P Sync + Tooling (v0.2.0)**
-
-### Overview
-
-Phase 9 focuses on completing and polishing the real-time synchronization layer while improving developer tooling:
-
-1. **WebRTC P2P Sync** - Real browser-to-browser synchronization (PR #149)
-2. **create-cliffy Library Mode** - Scaffold component libraries, not just apps
-3. **Documentation** - Complete create-cliffy and P2P sync documentation
-
-### 9.1 WebRTC P2P Sync (Completed in PR #149)
-
-Real peer-to-peer synchronization replacing the simulated network:
-
-```
-┌─────────────────┐     ┌─────────────────┐
-│   Browser A     │     │   Browser B     │
-│  ┌───────────┐  │     │  ┌───────────┐  │
-│  │ CRDT State│  │     │  │ CRDT State│  │
-│  └─────┬─────┘  │     │  └─────┬─────┘  │
-│  ┌─────▼─────┐  │     │  ┌─────▼─────┐  │
-│  │WebRTC     │◄─┼─────┼─►│WebRTC     │  │
-│  │Transport  │  │     │  │Transport  │  │
-│  └─────┬─────┘  │     │  └─────┬─────┘  │
-└────────┼────────┘     └────────┼────────┘
-         │   ┌───────────────┐   │
-         └──►│ Signaling     │◄──┘
-             │ Server (WS)   │
-             └───────────────┘
-```
-
-**Implemented**:
-- [x] `examples/shared/src/webrtc/types.ts` - Protocol types
-- [x] `examples/shared/src/webrtc/codec.ts` - Binary serialization
-- [x] `examples/shared/src/webrtc/transport.ts` - RTCPeerConnection wrapper
-- [x] `examples/shared/src/webrtc/signaling.ts` - WebSocket client
-- [x] `examples/shared/src/webrtc/peer-manager.ts` - High-level integration
-- [x] `examples/signaling-server/` - Node.js WebSocket relay
-
-**Polish Tasks**:
-- [ ] Add E2E tests for WebRTC sync (Playwright)
-- [ ] Improve error handling and reconnection logic
-- [ ] Add usage documentation to p2p-sync example
-- [ ] Deploy hosted signaling server (optional)
-
-### 9.2 create-cliffy Library Mode
-
-Extend the scaffolding tool to create component libraries:
-
-```bash
-npx create-cliffy my-lib
-# Select: "Component Library" instead of "Application"
-```
-
-**App vs Library Differences**:
-
-| Aspect | App | Library |
-|--------|-----|---------|
-| `private` | true | false |
-| Build output | Bundled | Unbundled ESM |
-| Entry point | `src/main.ts` | `src/index.ts` |
-| Vite mode | Default | `build.lib` |
-| TypeScript | Standard | Declarations enabled |
-| Exports | N/A | Package exports map |
-
-**Library Template Features**:
-- Vite library build mode with `vite-plugin-dts`
-- Peer dependencies on `@cliffy-ga/core`
-- TypeScript declaration generation
-- Example component included
-- Package exports map for proper ESM
-
-**Tasks**:
-- [ ] Add project type selection (app vs library) to CLI
-- [ ] Create `typescript-vite-library` template
-- [ ] Update scaffold.ts for library mode
-- [ ] Fix package name: `@cliffy/core` → `@cliffy-ga/core`
-- [ ] Update CLIFFY_VERSION to `0.1.3`
-
-### 9.3 create-cliffy Documentation
-
-Create comprehensive documentation for the scaffolding tool:
-
-**Tasks**:
-- [ ] Write `tools/create-cliffy/README.md`
-  - Installation and usage
-  - Available templates (typescript-vite, bun, purescript)
-  - App vs Library mode
-  - Template customization guide
-  - Contributing guide
-
-### Dependencies
-
-| Package | Purpose |
-|---------|---------|
-| `vite-plugin-dts` | TypeScript declarations for library builds |
-| `ws` | WebSocket for signaling server |
-
----
-
-## Phase 9-DEFERRED: Native Mobile (Trebek) → v0.5.0
-
-**Note**: Mobile support has been deferred to v0.5.0 to prioritize component library and Living UI work.
-
-**Goal**: Algebraic UI middleware for React Native and Lynx—pure functional state machines with zero hooks.
-
-**🎯 Milestone: Mobile Support (v0.5.0)**
-
-### Motivation
-
-React Native and ByteDance's Lynx framework represent the two major approaches to cross-platform mobile development. Both use React paradigms but with fundamentally different runtime architectures:
-
-| Aspect | React Native | Lynx |
-|--------|--------------|------|
-| Threading | JSI + TurboModules | Dual-thread (PrimJS + UI thread) |
-| Styling | StyleSheet abstraction | Native CSS with selectors |
-| Elements | `<View>`, `<Text>` (imported) | `<view>`, `<text>` (intrinsic) |
-| Animation | Animated/Reanimated | CSS transitions + main thread |
-
-A shared component library that tries to hide these differences behind adapters inevitably leaks. Trebek takes a different approach: **parallel implementations with shared algebraic middleware**.
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     Trebek Middleware                          │
-│  (State machines, Behaviors, Events, geometric embedding)       │
-│              100% shared, zero platform awareness               │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │
-              ┌─────────────┴─────────────┐
-              │                           │
-              ▼                           ▼
-┌─────────────────────────┐     ┌─────────────────────────┐
-│   React Native Shell    │     │      Lynx Shell         │
-│                         │     │                         │
-│  • StyleSheet           │     │  • Native CSS           │
-│  • Animated/Reanimated  │     │  • Dual-thread aware    │
-│  • TurboModules         │     │  • PrimJS runtime       │
-│  • Gesture Handler      │     │  • bindtap/bindtouch    │
-└─────────────────────────┘     └─────────────────────────┘
-```
-
-### Core Principle: No Hooks
-
-Hooks are antithetical to algebraic FRP:
-- Call-order invariants obscure dataflow
-- Closure capture creates implicit state
-- Rules-of-hooks are runtime constraints, not type-level guarantees
-
-Trebek uses Cliffy's `Behavior<T>` and `Event<T>` primitives directly. State lives in machines. Machines are pure data.
-
-### 9.1 FRP Primitives (from cliffy-core)
-
-Trebek reuses Cliffy's FRP foundation:
-
-```rust
-// Behavior<A> ≅ Time → A (continuous, always has current value)
-// Event<A> ≅ [(Time, A)] (discrete occurrences)
-
-// The fundamental FRP combinator
-fn stepper<A>(initial: A, updates: Event<A>) -> Behavior<A>;
-
-// Behaviors are Applicative
-impl<A> Behavior<A> {
-    fn map<B>(self, f: impl Fn(A) -> B) -> Behavior<B>;
-    fn ap<B>(self, bf: Behavior<impl Fn(A) -> B>) -> Behavior<B>;
-}
-
-// Events are Filterable + Foldable
-impl<A> Event<A> {
-    fn filter(self, pred: impl Fn(&A) -> bool) -> Event<A>;
-    fn fold<B>(self, initial: B, f: impl Fn(B, A) -> B) -> Behavior<B>;
-    fn snapshot<B>(self, behavior: Behavior<B>) -> Event<(A, B)>;
-}
-```
-
-### 9.2 State Machines as Coalgebras
-
-```rust
-/// A state machine is a coalgebra for F(X) = A × (E → X)
-pub trait Machine<S, E, A> {
-    fn initial(&self) -> S;
-    fn transition(&self, state: S, event: E) -> S;
-    fn output(&self, state: &S) -> A;
-
-    /// Optional geometric embedding for interpolation/animation
-    fn embed(&self, state: &S) -> Option<GA8>;
-}
-
-/// Run machine: Event<E> → Behavior<A>
-fn run_machine<S, E, A>(
-    machine: impl Machine<S, E, A>,
-    events: Event<E>
-) -> Behavior<A> {
-    events
-        .fold(machine.initial(), |s, e| machine.transition(s, e))
-        .map(|s| machine.output(&s))
-}
-
-/// Compose machines in parallel
-fn parallel<M1, M2>(m1: M1, m2: M2) -> ParallelMachine<M1, M2>;
-
-/// Compose machines sequentially
-fn sequence<M1, M2>(m1: M1, m2: M2) -> SequenceMachine<M1, M2>;
-```
-
-### 9.3 Geometric Embedding (8D UI Space)
-
-UI state embeds in an 8-dimensional Clifford algebra:
-
-| Grade 1 Basis | Dimension | Meaning |
-|---------------|-----------|---------|
-| e₁ | x | Horizontal position |
-| e₂ | y | Vertical position |
-| e₃ | width | Element width |
-| e₄ | height | Element height |
-| e₅ | z-index | Stacking order |
-| e₆ | opacity | Transparency [0,1] |
-| e₇ | rotation | Rotation angle |
-| e₈ | scale | Uniform scale factor |
-
-```rust
-/// Embed component state for geometric interpolation
-fn embed_toggle(state: &ToggleState) -> GA8 {
-    mv::vector([
-        state.thumb_x,      // x: thumb position
-        0.0,                // y: fixed
-        40.0,               // width: track width
-        24.0,               // height: track height
-        0.0,                // z-index
-        1.0,                // opacity
-        0.0,                // rotation
-        1.0,                // scale
-    ])
-}
-
-/// Geometric interpolation for smooth animations
-fn animate(from: GA8, to: GA8, duration: Duration) -> Behavior<GA8> {
-    animation_frame
-        .fold(0.0, |t, dt| (t + dt).min(1.0))
-        .map(|t| {
-            let eased = ease_out_cubic(t);
-            mv::lerp(&from, &to, eased)
-        })
-}
-```
-
-### 9.4 Platform Adapters
-
-```rust
-/// Abstract interface both platforms implement
-pub trait PlatformAdapter {
-    type Handle;
-
-    /// Create native view
-    fn create_view(&self, spec: &ViewSpec) -> Self::Handle;
-
-    /// Bind behavior to view property (auto-updates)
-    fn bind<A>(&self, handle: &Self::Handle, prop: &str, behavior: Behavior<A>);
-
-    /// Connect native event to Event stream
-    fn connect(&self, handle: &Self::Handle, event_name: &str) -> Event<NativeEvent>;
-
-    /// Animation frame source
-    fn animation_frame(&self) -> Event<Duration>;
-
-    /// Geometric interpolation (can use platform animation system)
-    fn interpolate(&self, from: GA8, to: GA8, duration: Duration) -> Behavior<GA8>;
-}
-```
-
-**React Native Adapter:**
-```rust
-impl PlatformAdapter for ReactNativeAdapter {
-    // Uses Animated.Value for numeric behaviors
-    // TurboModules for native bridge
-    // Reanimated worklets for gesture-driven animation
-}
-```
-
-**Lynx Adapter:**
-```rust
-impl PlatformAdapter for LynxAdapter {
-    // Leverages dual-thread architecture
-    // CSS transitions for declarative animation
-    // Main thread scripts for complex interactions
-}
-```
-
-### 9.5 Component Definition
-
-```rust
-/// Platform-agnostic component specification
-pub struct Component<Props, State, Events: EventSet> {
-    pub machine: Box<dyn Machine<State, Events::Union, State>>,
-    pub project: fn(&State, &Props) -> ViewProps,
-    pub embed: Option<fn(&State) -> GA8>,
-}
-
-/// Example: Counter component
-const COUNTER: Component<CounterProps, CounterState, CounterEvents> = Component {
-    machine: Box::new(CounterMachine),
-    project: |state, _props| ViewProps {
-        text: Some(state.count.to_string().into()),
-        ..Default::default()
-    },
-    embed: Some(|s| mv::vector([s.count as f64, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0])),
-};
-```
-
-### 9.6 View Specification
-
-```rust
-/// Platform-agnostic view tree
-pub struct ViewSpec {
-    pub element_type: ElementType,
-    pub props: ViewProps,
-    pub events: EventBindings,
-    pub children: Vec<ViewChild>,
-}
-
-pub enum ViewChild {
-    Static(ViewSpec),
-    Dynamic(Behavior<ViewSpec>),
-    List { items: Behavior<Vec<ViewSpec>>, key: fn(&ViewSpec) -> String },
-}
-
-/// Props can be static or reactive
-pub struct ViewProps {
-    pub x: Option<PropValue<f64>>,
-    pub y: Option<PropValue<f64>>,
-    pub width: Option<PropValue<f64>>,
-    pub height: Option<PropValue<f64>>,
-    pub opacity: Option<PropValue<f64>>,
-    pub rotation: Option<PropValue<f64>>,
-    pub scale: Option<PropValue<f64>>,
-    pub text: Option<PropValue<String>>,
-    pub style: Option<StyleMap>,
-    // ...
-}
-
-pub enum PropValue<T> {
-    Static(T),
-    Reactive(Behavior<T>),
-}
-```
-
-### Tasks
-
-**9.1 Core Middleware**
-- [ ] Create `trebek-core` crate
-- [ ] Port `Behavior<T>` and `Event<T>` from cliffy-core (or re-export)
-- [ ] Implement `Machine` trait with coalgebraic semantics
-- [ ] Add machine composition (parallel, sequence)
-- [ ] Implement 8D geometric embedding
-
-**9.2 Platform Adapters**
-- [ ] Define `PlatformAdapter` trait
-- [ ] Implement React Native adapter (TurboModules integration)
-- [ ] Implement Lynx adapter (dual-thread aware)
-- [ ] Add animation frame synchronization
-- [ ] Implement geometric interpolation per platform
-
-**9.3 View System**
-- [ ] Define `ViewSpec` and `ViewProps` types
-- [ ] Implement reactive prop binding
-- [ ] Add event connection system
-- [ ] Create view diffing for dynamic children (non-VDOM, structural)
-
-**9.4 TypeScript API**
-- [ ] Generate TypeScript types from Rust
-- [ ] Create idiomatic TS API for component definition
-- [ ] Add TSX support via build plugin (optional, not required)
-- [ ] Export platform adapters for RN and Lynx
-
-**9.5 Testing**
-- [ ] Port `cliffy-test` patterns for component testing
-- [ ] Add machine property tests (transition determinism, output consistency)
-- [ ] Create geometric invariant tests for animations
-- [ ] Implement cross-platform snapshot testing
-
-**9.6 Example Components**
-- [ ] Counter (minimal state machine)
-- [ ] Toggle with animation (geometric interpolation)
-- [ ] Form with validation (composed machines)
-- [ ] Gesture-driven component (event composition)
-- [ ] List with add/remove (dynamic children)
-
-### Dependencies
-
-| Crate | Purpose |
-|-------|---------|
-| `cliffy-core` | FRP primitives (Behavior, Event) |
-| `amari-core` | Geometric algebra (GA8 for embeddings) |
-| `amari-flynn` | Probabilistic contracts for testing |
-
----
-
-## Phase 9.5: Amari 0.19.0 Upgrade (Foundation Hardening)
-
-**Goal**: Upgrade all crates to Amari 0.19.0 and adopt typed geometric primitives (Rotor, Vector, Bivector), SMT proof obligations, and statistical bounds throughout the framework.
-
-**Prerequisites**: None — this is foundational work that strengthens all subsequent phases.
-
-### Motivation
-
-Amari 0.19.0 introduces three major capabilities that directly address Cliffy's architecture:
-
-1. **Typed geometric primitives** (`Rotor<P,Q,R>`, `Vector<P,Q,R>`, `Bivector<P,Q,R>`) — replaces raw `GA3` multivector usage with compile-time grade safety
-2. **SMT-LIB2 proof obligations** (`SmtProofObligation`) — enables formal verification of probabilistic contracts, exportable to Z3/CVC5
-3. **Statistical bounds** (`hoeffding_bound`, `chernoff_bound`, `confidence_interval`) — tightens probabilistic test verification with mathematical rigor
-
-### 9.5.1 cliffy-test: SMT Backend + Statistical Bounds
-
-Upgrade amari-flynn from 0.17.0 → 0.19.0 and integrate new verification backends.
-
-**Changes**:
-- Bump `amari-flynn` dependency to 0.19.0
-- Add `export_smt()` to `ImpossibleInvariant` — generates `precondition_obligation()` for formal proof
-- Add `export_smt()` to `RareInvariant` — generates `hoeffding_obligation()` with sample count and epsilon
-- Enrich `InvariantTestReport` with `confidence_interval: Option<(f64, f64)>` using `estimate_probability()`
-- Use `hoeffding_bound()` in `RareInvariant` to compute required sample count for target confidence
-- Use `confidence_interval()` for richer reporting in test output
-- Add `verify_with_smt()` method that cross-verifies Monte Carlo results against SMT obligations
-- Optional: Wire up `Why3Generator` pipeline for future formal verification
-
-**Tasks**:
-- [ ] Bump amari-flynn 0.17.0 → 0.19.0 in cliffy-test/Cargo.toml
-- [ ] Add SMT export to ImpossibleInvariant (precondition_obligation)
-- [ ] Add SMT export to RareInvariant (hoeffding_obligation)
-- [ ] Add confidence_interval field to InvariantTestReport
-- [ ] Use hoeffding_bound() for adaptive sample count in RareInvariant
-- [ ] Use estimate_probability() for (estimate, lower, upper) reporting
-- [ ] Add verify_with_smt() cross-verification method
-- [ ] Update all existing tests to work with 0.19.0 API
-- [ ] Add new tests for SMT export and statistical bounds
-
-### 9.5.2 cliffy-core: Typed Rotor API
-
-Adopt Amari's typed `Rotor<3,0,0>` for geometric state transformations.
-
-**Changes**:
-- Use `Rotor<3,0,0>` instead of raw GA3 for rotation operations in GeometricState
-- Use `Vector<3,0,0>` for position/displacement components
-- Use `Rotor::slerp()` for state interpolation (replaces ad-hoc blend)
-- Use `Rotor::compose()` for transform composition
-- Evaluate `phantom-types` feature for VerifiedMultivector in critical paths
-
-**Tasks**:
-- [ ] Audit all GA3 usage in cliffy-core for type opportunities
-- [ ] Replace rotation operations with typed Rotor<3,0,0>
-- [ ] Replace vector operations with typed Vector<3,0,0>
-- [ ] Use Rotor::slerp() for GeometricState.blend()
-- [ ] Use Rotor::compose() for transform chaining
-- [ ] Ensure all 79 existing tests pass with typed API
-- [ ] Add new tests for typed rotor operations
-
-### 9.5.3 cliffy-protocols: Type-Safe Distributed State
-
-Replace raw GA3 usage with typed geometric primitives for compile-time safety in CRDT, consensus, and sync operations.
-
-**Changes**:
-- **CRDT**: Use `Rotor<3,0,0>` for sandwich operations, `Rotor::apply()` instead of manual `geometric_product + reverse`
-- **Delta encoding**: Type deltas by encoding — `Vector` for Additive, `Rotor` for Multiplicative, `Bivector` for Compressed
-- **Consensus**: Use `Rotor::slerp()` for geometric mean (mathematically correct manifold interpolation)
-- **Lattice**: Use `grade_magnitude()` and `norm_squared()` for efficient grade-aware operations
-- **Storage**: Use `VerifiedMultivector` at snapshot boundaries for integrity checking on load
-- **Performance**: Replace `magnitude()` comparisons with `norm_squared()` to avoid unnecessary sqrt
-
-**Tasks**:
-- [ ] Replace CRDT sandwich product with Rotor::apply()
-- [ ] Type delta encodings (Vector/Rotor/Bivector)
-- [ ] Replace consensus geometric mean with Rotor::slerp()
-- [ ] Use grade_magnitude() in lattice operations
-- [ ] Replace magnitude() with norm_squared() in comparisons
-- [ ] Add VerifiedMultivector at storage snapshot boundaries
-- [ ] Update Rotor composition to use Rotor::compose()
-- [ ] Use Rotor::logarithm() and Rotor::power() in compressed delta encoding
-- [ ] Ensure all 42 existing tests pass with typed API
-- [ ] Add new tests for typed operations
-
-### 9.5.4 cliffy-alive: amari-automata Integration (deferred to Phase 11)
-
-When cliffy-alive development resumes, integrate `amari-automata` as the mathematical backbone:
-
-- Replace custom cellular automata with `GeometricCA`
-- Use `InverseDesigner` for target layout discovery
-- Use `SelfAssembler` / `UIAssembler` for self-assembling UI components
-- Use `CayleyNavigator` for algebraic structure exploration
-- Use `TropicalSolver` for optimization problems
-
-This work is deferred to Phase 11 since cliffy-alive is on its own feature branch.
-
-### Dependencies Between Sub-phases
-
-```
-9.5.1 (cliffy-test)     ← no dependencies, start here
-       ↓
-9.5.2 (cliffy-core)     ← typed API patterns established in tests first
-       ↓
-9.5.3 (cliffy-protocols) ← depends on cliffy-core typed API
-       ↓
-9.5.4 (cliffy-alive)    ← deferred to Phase 11, depends on all above
-```
-
----
-
-## Phase 10: Component Library (cliffy-components) → v0.3.0
-
-**Goal**: A standard library of geometric components built on Phase 4's foundation, preparing for Living UI integration.
-
-**🎯 Milestone: Component Library (v0.3.0)**
-
-### Overview
-
-The component library provides standard UI primitives with geometric state, serving as the foundation for Living UI variants:
-
-### 10.1 Core Components
-
-Standard UI primitives with geometric state:
-
-```rust
-/// Button with geometric state for animations
-pub struct Button {
-    label: Behavior<String>,
-    disabled: Behavior<bool>,
-    // 8D state: position, size, opacity, scale for hover/press
-    state: GeometricState,
-}
-
-impl Component for Button {
-    fn render(&self, state: &GA3) -> Element {
-        Element::tag("button")
-            .class("cliffy-button")
-            .class_if("disabled", self.disabled.sample())
-            .style("transform", self.state.to_transform())
-            .text(&self.label.sample())
-            .on("click", self.on_click.clone())
-    }
-}
-```
-
-**Components**:
-- [ ] `Button` - Click target with press/hover states
-- [ ] `Input` - Text input with validation state
-- [ ] `Select` - Dropdown with geometric transitions
-- [ ] `Checkbox` / `Radio` - Toggle controls
-- [ ] `Slider` - Range input with geometric thumb
-- [ ] `Modal` - Overlay with geometric entry/exit
-- [ ] `Tooltip` - Positioned overlay
-- [ ] `Tabs` - Tab navigation with transitions
-
-### 10.2 Layout Components
-
-Geometric layout primitives:
-
-```rust
-/// Flexbox-like layout with geometric spacing
-pub struct Stack {
-    direction: Behavior<Direction>,
-    spacing: Behavior<f64>,
-    children: Vec<Element>,
-}
-
-/// Grid layout with geometric cell sizing
-pub struct Grid {
-    columns: Behavior<usize>,
-    gap: Behavior<f64>,
-    children: Vec<Element>,
-}
-```
-
-**Components**:
-- [ ] `Stack` - Vertical/horizontal stacking
-- [ ] `Grid` - Grid layout
-- [ ] `Canvas` - Absolute positioning
-- [ ] `Scroll` - Scrollable container
-- [ ] `Split` - Resizable split panes
-
-### 10.3 Form Components
-
-Form handling with geometric validation:
-
-```rust
-/// Form with geometric validation feedback
-pub struct Form {
-    fields: Vec<FormField>,
-    validation: ValidationState,
-    on_submit: Event<FormData>,
-}
-
-/// Validation state as geometric distance from valid manifold
-pub struct ValidationState {
-    /// 0 = valid, >0 = distance from validity
-    error_distance: Behavior<f64>,
-    /// Error messages projected from validation manifold
-    errors: Behavior<Vec<ValidationError>>,
-}
-```
-
-**Components**:
-- [ ] `Form` - Form container with validation
-- [ ] `FormField` - Labeled input wrapper
-- [ ] `ValidationMessage` - Error display
-- [ ] `FormActions` - Submit/cancel buttons
-
-### 10.4 Theming System
-
-Geometric theming with smooth transitions:
-
-```rust
-/// Theme as a point in color/spacing geometric space
-pub struct Theme {
-    colors: ColorPalette,
-    spacing: SpacingScale,
-    typography: TypographyScale,
-    animations: AnimationCurves,
-}
-
-/// Switch themes via geometric interpolation
-pub fn transition_theme(from: &Theme, to: &Theme, duration: Duration) -> Behavior<Theme>;
-```
-
-**Tasks**:
-- [ ] Define theme structure
-- [ ] Implement theme context
-- [ ] Add geometric theme transitions
-- [ ] Create default light/dark themes
-- [ ] Add theme customization API
-
-### Dependencies
-
-| Crate | Purpose |
-|-------|---------|
-| `cliffy-core` | FRP primitives, Component trait |
-| `cliffy-wasm` | DOM projection |
-
----
-
-## Phase 11: Living UI Revival (cliffy-alive) → v0.4.0
-
-**Goal**: Resurrect the Living UI system where components are living cells that evolve based on user interaction, integrated with the new architecture.
-
-**🎯 Milestone: Living UI (v0.4.0)**
-
-### Background
-
-The archived `cliffy-alive` crate implements a revolutionary paradigm: UI components as living cells in 8-dimensional geometric space. Each cell has:
-- **DNA**: Genetic traits governing behavior (energy efficiency, cooperation, mutation rate)
-- **Energy**: Metabolic system with consumption, diffusion, and death thresholds
-- **Physics**: Spatial forces, collision detection, and geometric movement
-- **Nervous System**: Signal propagation and inter-cell communication
-- **Evolution**: Selection, crossover, and mutation based on fitness
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     Living UI Field                              │
-│                                                                 │
-│   ┌────┐  ┌────┐       ┌────┐                                   │
-│   │Cell│──│Cell│ ···   │Cell│   Cells interact via:             │
-│   │ A  │  │ B  │       │ N  │   • Energy diffusion              │
-│   └────┘  └────┘       └────┘   • Genetic affinity forces       │
-│      ↓       ↓            ↓     • Neural signaling              │
-│   ┌─────────────────────────┐   • Spatial physics               │
-│   │   Evolution Engine       │                                   │
-│   │ (Selection + Mutation)   │                                   │
-│   └─────────────────────────┘                                   │
-│              ↓                                                  │
-│   ┌─────────────────────────┐                                   │
-│   │   User Fitness Feedback  │   Interactions provide fitness   │
-│   │   (clicks, hovers, etc)  │   signals for natural selection  │
-│   └─────────────────────────┘                                   │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### 11.1 Migration to New Architecture
-
-Update `cliffy-alive` to use the refactored `cliffy-core` types:
-
-```rust
-// Before (archived): Used ReactiveMultivector<GA3>
-pub trait LivingComponent: Send + Sync {
-    fn geometric_state(&self) -> &ReactiveMultivector<GA3>;
-    // ...
-}
-
-// After: Use Phase 1's GeometricState and Phase 4's Component
-pub trait LivingComponent: Component + Send + Sync {
-    fn geometric_state(&self) -> &GeometricState;
-    fn energy_level(&self) -> f64;
-    fn step(&mut self, dt: f64);
-    fn is_alive(&self) -> bool;
-    fn dna(&self) -> &CellDNA;
-}
-```
-
-**Tasks**:
-- [ ] Move `cliffy-alive` from archive to workspace
-- [ ] Update imports to use new `cliffy-core` API
-- [ ] Replace `ReactiveMultivector` with `GeometricState`
-- [ ] Implement `Component` trait for `UICell`
-- [ ] Update tests for new API
-- [ ] Ensure 66 existing tests pass
-
-### 11.2 Integration with Component Model
-
-Living cells should compose with Phase 4's algebraic components:
-
-```rust
-/// A UICell is both a Component and a LivingComponent
-impl Component for UICell {
-    fn render(&self, state: &GA3) -> Element {
-        // Project cell's 8D state to DOM element
-        let pos = self.geometric_state().position();
-        let visual = self.geometric_state().visual_properties();
-
-        Element::tag("div")
-            .style("transform", format!("translate({}px, {}px)", pos.x, pos.y))
-            .style("opacity", visual.opacity)
-            .style("z-index", visual.z_index)
-            .children(self.render_content())
-    }
-}
-
-/// Compose living cells into organisms
-fn create_organism() -> ComposedComponent<UIOrganismField, Vec<UICell>> {
-    let field = UIOrganismField::new(config);
-    let cells = (0..100).map(|_| UICell::random()).collect();
-    compose(field, cells)
-}
-```
-
-**Tasks**:
-- [ ] Implement `Component` for `UICell`
-- [ ] Implement `Component` for `UIOrganismField`
-- [ ] Add composition with standard components
-- [ ] Create hybrid examples (living + static components)
-
-### 11.3 8D Geometric Embedding
-
-The 8-dimensional state space maps directly to CSS properties:
-
-| Dimension | Basis | CSS Property | Range |
-|-----------|-------|--------------|-------|
-| 1 | e₁ | `left` / `translateX` | pixels |
-| 2 | e₂ | `top` / `translateY` | pixels |
-| 3 | e₃ | `width` | pixels |
-| 4 | e₄ | `height` | pixels |
-| 5 | e₅ | `z-index` | integer |
-| 6 | e₆ | `opacity` | [0, 1] |
-| 7 | e₇ | `rotate` | degrees |
-| 8 | e₈ | `scale` | factor |
-
-```rust
-/// Project 8D state to CSS
-impl UICell {
-    pub fn to_css(&self) -> CSSProperties {
-        let mv = self.geometric_state().multivector();
-        CSSProperties {
-            transform: format!(
-                "translate({}px, {}px) rotate({}deg) scale({})",
-                mv.component(1), mv.component(2),
-                mv.component(7), mv.component(8)
-            ),
-            width: format!("{}px", mv.component(3)),
-            height: format!("{}px", mv.component(4)),
-            z_index: mv.component(5) as i32,
-            opacity: mv.component(6).clamp(0.0, 1.0),
-        }
-    }
-}
-```
-
-**Tasks**:
-- [ ] Define GA8 type alias in cliffy-core
-- [ ] Implement 8D → CSS projection
-- [ ] Add geometric interpolation for smooth animations
-- [ ] Create SLERP-based cell movement
-
-### 11.4 Evolution Engine Refinement
-
-Enhance the genetic algorithm with geometric fitness:
-
-```rust
-/// Fitness is a geometric distance in behavior space
-pub struct FitnessFunction {
-    /// Target behavior manifold
-    target_manifold: Manifold<GA8>,
-    /// Weight different aspects
-    weights: FitnessWeights,
-}
-
-impl FitnessFunction {
-    pub fn evaluate(&self, cell: &UICell, interactions: &[UserInteraction]) -> f64 {
-        // Geometric distance from ideal behavior
-        let behavior_state = cell.encode_behavior();
-        let manifold_distance = self.target_manifold.distance_to(&behavior_state);
-
-        // User interaction fitness
-        let interaction_fitness = interactions.iter()
-            .filter(|i| i.target == cell.id())
-            .map(|i| i.fitness_contribution())
-            .sum::<f64>();
-
-        // Combined fitness (lower distance = higher fitness)
-        self.weights.manifold * (1.0 / (1.0 + manifold_distance))
-            + self.weights.interaction * interaction_fitness
-    }
+        .reduce(GA3::zero, |a, b| &a + &b)
+        .exp()
 }
-```
-
-**Tasks**:
-- [ ] Implement geometric fitness functions
-- [ ] Add manifold-based selection pressure
-- [ ] Create fitness visualization tools
-- [ ] Benchmark evolution performance
-
-### 11.5 WASM Bindings
-
-Expose Living UI to JavaScript:
-
-```typescript
-// JavaScript API
-import { UIOrganismField, UICell, EvolutionConfig } from '@cliffy/alive';
-
-const field = new UIOrganismField({
-    dimensions: [800, 600],
-    initialCells: 50,
-    evolution: {
-        mutationRate: 0.01,
-        selectionPressure: 0.5,
-    }
-});
-
-// Mount to DOM
-field.mount(document.getElementById('container'));
-
-// Start the living simulation
-field.start();
-
-// Provide fitness feedback
-document.addEventListener('click', (e) => {
-    const cell = field.cellAt(e.clientX, e.clientY);
-    if (cell) {
-        cell.addFitness(1.0); // Reward clicked cells
-    }
-});
-```
-
-**Tasks**:
-- [ ] Add `#[wasm_bindgen]` to core types
-- [ ] Create `UIOrganismField` JavaScript API
-- [ ] Add DOM mounting and unmounting
-- [ ] Implement fitness feedback API
-- [ ] Create TypeScript type definitions
-
-### 11.6 Living UI Examples
-
-Demonstrate the paradigm with compelling examples:
-
-| Example | Description |
-|---------|-------------|
-| `alive-garden` | Cells grow and evolve like plants, user attention is sunlight |
-| `alive-dashboard` | Dashboard widgets that reorganize based on usage patterns |
-| `alive-navigation` | Menu items that evolve prominence based on click frequency |
-| `alive-forms` | Form fields that adapt layout to user behavior |
-
-**Tasks**:
-- [ ] Create `examples/alive-garden`
-- [ ] Create `examples/alive-dashboard`
-- [ ] Create `examples/alive-navigation`
-- [ ] Create `examples/alive-forms`
-- [ ] Add interactive playground
-
----
-
-## Success Criteria
-
-### Phase 0 ✅ (Algebraic Testing Framework - COMPLETE)
-- [x] `cliffy-test` crate compiles (25 tests passing)
-- [x] `invariant!` macro generates property tests
-- [x] Test failures include geometric error information
-- [x] `invariant_impossible!`, `invariant_rare!`, `emergent!` macros work
-- [x] Manifold testing with constraints
-- [ ] Cross-layer homomorphism tests (partial)
-- [ ] Monte Carlo verification for distributed properties (partial)
-
-### Phase 1
-- [ ] Geometric operations exposed in API
-- [ ] Projections from multivector to user types
-- [ ] WASM bindings work in browser
-
-### Phase 2 ✅ (Distributed State - COMPLETE)
-- [x] cliffy-protocols compiles and tests pass (42 tests)
-- [x] Lattice operations with proven convergence
-- [x] CRDT merge is correct and efficient
-- [x] Vector clocks for causal ordering
-- [x] Delta compression and batching
-- [x] Storage layer with snapshots
-
-### Phase 3
-- [ ] P2P sync works across browsers
-- [ ] Delta compression reduces bandwidth
-- [ ] Persistence survives page reload
-
-### Phase 4
-- [ ] TSX compiles to dataflow graphs
-- [ ] Direct DOM updates (no VDOM)
-- [ ] Build-time optimization works
-
-### Phase 5 (Edge Computing - PARTIAL)
-- [x] WebGPU acceleration functional (cliffy-gpu, 18 tests)
-- [x] SIMD fallback for non-GPU environments
-- [x] Benchmark suite with CPU vs GPU comparison (gpu-benchmark example)
-- [ ] Distributed compute across peers
-- [ ] 60fps with complex state (needs testing)
-- [ ] Performance regression tests integrated with CI
-- [ ] Documented batch size thresholds for GPU benefit
-
-### Phase 6 (Production Readiness - PARTIAL)
-- [x] Example applications functional (13 deployed to Netlify)
-- [x] CPU/GPU comparison demos (gpu-benchmark example)
-- [x] Load testing framework (cliffy-loadtest, 15 tests)
-- [ ] 10,000 concurrent users tested
-- [ ] Documentation complete
-- [ ] Each example includes embedded performance benchmarks
-- [ ] Benchmark results exportable and reproducible
-
-### Phase 7 (Documentation - PARTIAL)
-- [x] CLAUDE.md with architecture and patterns
-- [x] README.md with quick start
-- [x] Algebraic TSX implementation documented in ROADMAP
-- [x] PureScript bindings documented
-- [ ] Full rustdoc coverage for all crates
-- [ ] Getting Started guide complete
-- [ ] Conceptual guides for all major topics
-- [ ] Interactive tutorials functional
-- [ ] Architecture documentation with ADRs
-
-### Phase 8 → v0.1.x ✅ (First Public Release - COMPLETE)
-- [x] TypeScript examples complete and tested (12 examples on Netlify)
-- [x] PureScript examples demonstrate FP patterns (2 examples)
-- [x] All examples have CI testing (GitHub Actions)
-- [x] **Released**: `@cliffy-ga/core` v0.1.3 on npm
-- [ ] JavaScript examples work without bundler (deferred to v0.2.0)
-- [ ] CoffeeScript examples (deferred to v0.2.0)
-- [ ] Cross-language comparison guide (deferred to v0.2.0)
-
-### Phase 9 → v0.2.0 (P2P Sync + Tooling)
-- [x] WebRTC P2P sync implemented (PR #149)
-- [ ] P2P sync E2E tests passing
-- [ ] create-cliffy library mode working
-- [ ] create-cliffy documentation complete
-- [ ] Package references updated to `@cliffy-ga/core`
-- [ ] **Release**: Publish `@cliffy-ga/core` v0.2.0 to npm
-
-### Phase 9.5 (Amari 0.19.0 Upgrade)
-- [ ] amari-flynn bumped to 0.19.0 in cliffy-test
-- [ ] SMT export working for Impossible and Rare invariants
-- [ ] InvariantTestReport includes confidence intervals
-- [ ] cliffy-core uses typed Rotor<3,0,0> for rotations
-- [ ] cliffy-core uses typed Vector<3,0,0> for positions
-- [ ] cliffy-protocols CRDT uses Rotor::apply() for sandwich products
-- [ ] cliffy-protocols consensus uses Rotor::slerp()
-- [ ] cliffy-protocols delta encoding typed (Vector/Rotor/Bivector)
-- [ ] All existing tests pass across all three crates (79 + 42 + 25)
-
-### Phase 10 → v0.3.0 (Component Library)
-- [ ] Core component set implemented (Button, Input, Select, etc.)
-- [ ] Layout components working (Stack, Grid, Canvas)
-- [ ] Form components with validation
-- [ ] Theming system with geometric transitions
-- [ ] Component documentation complete
-- [ ] **Release**: Publish `@cliffy-ga/components` v0.3.0 to npm
-
-### Phase 11 → v0.4.0 (Living UI)
-- [ ] cliffy-alive migrated to new architecture
-- [ ] All 66 existing tests pass
-- [ ] UICell implements Component trait
-- [ ] 8D geometric embedding working
-- [ ] WASM bindings functional
-- [ ] Living UI examples demonstrate paradigm
-- [ ] Living component variants integrated with component library
-- [ ] **Release**: Publish `@cliffy-ga/alive` v0.4.0 to npm
-
-### Phase 12 → v0.5.0 (Mobile Support - Deferred)
-- [ ] Same middleware code runs on both RN and Lynx
-- [ ] Zero hooks in application code
-- [ ] State machines compose algebraically
-- [ ] Animations use geometric interpolation
-- [ ] TypeScript API feels idiomatic
-- [ ] Performance matches or exceeds hooks-based equivalent
-- [ ] **Release**: Publish `@cliffy-ga/trebek` v0.5.0 to npm
-
----
-
-## Architecture Summary
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        Applications                              │
-│  (Collaborative Docs, Games, Design Tools, Whiteboards)         │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-        ┌─────────────────────┼─────────────────────┐
-        │                     │                     │
-        ▼                     ▼                     ▼
-┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐
-│  Algebraic TSX  │   │   Living UI     │   │ Trebek (Mobile) │
-│  (dataflow→DOM) │   │ (cells→evolve)  │   │ (machines→nat.) │
-└─────────────────┘   └─────────────────┘   └─────────────────┘
-        │                     │                     │
-        └─────────────────────┼─────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                    Component Library                             │
-│  (Button, Input, List, Table, Form, Layout, Living variants)    │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                    Synchronization Layer                         │
-│  (WebRTC, deltas, persistence, peer discovery)                  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                    Distributed State                             │
-│  (Geometric CRDT, lattice join, vector clocks, merge)           │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                  Geometric State Layer                           │
-│  (Rotors, versors, projections, transformations)                │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                        FRP Core                                  │
-│  (Behavior, Event, combinators)                                 │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                    Geometric Algebra                             │
-│  (amari-core: GA3, rotors, exponentials, products)              │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-┌─────────────────────────────────────────────────────────────────┐
-│                      Acceleration                                │
-│  (WASM, WebGPU, SIMD)                                           │
-└─────────────────────────────────────────────────────────────────┘
-
-
-                    CROSS-CUTTING CONCERNS
-                    ──────────────────────
-
-┌─────────────────────────────────────────────────────────────────┐
-│                    cliffy-test                                   │
-│  Algebraic Testing Framework                                    │
-│                                                                 │
-│  • Tests as geometric invariants (not boolean assertions)       │
-│  • Failures as geometric distances from manifolds               │
-│  • Test composition via geometric product                       │
-│  • Proof-carrying tests for algebraic laws                      │
-│  • Cross-layer homomorphism verification                        │
-│  • Visual debugging with geometric error visualization          │
-└─────────────────────────────────────────────────────────────────┘
 ```
-
----
 
-## Getting Started
-
-To begin Phase 1 development:
-
-```bash
-# Current working state
-cargo test -p cliffy-core
-cargo test -p cliffy-wasm
-
-# Build WASM
-wasm-pack build cliffy-wasm --target web --out-dir pkg
-
-# Next: Add geometric state primitives
-# See Phase 1.1 tasks above
-```
+### Classical FRP
+- `Behavior<T>` = `Time → T` (continuous, time-varying value)
+- `Event<T>` = `[(Time, T)]` (discrete occurrences)
+- Never implement React-style hooks — the reactive graph handles everything

--- a/cliffy-core/Cargo.toml
+++ b/cliffy-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliffy-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Reactive UI framework with geometric algebra state management"
 license = "MIT"

--- a/cliffy-gpu/Cargo.toml
+++ b/cliffy-gpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliffy-gpu"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "WebGPU compute shaders for geometric algebra operations"
 license = "MIT"
@@ -10,14 +10,14 @@ keywords = ["gpu", "webgpu", "geometric-algebra", "simd", "wasm"]
 categories = ["graphics", "mathematics", "wasm"]
 
 [dependencies]
-cliffy-core = { version = "0.3.0", path = "../cliffy-core" }
+cliffy-core = { version = "0.3.1", path = "../cliffy-core" }
 amari-core = { workspace = true }
 wgpu = { version = "24.0", default-features = false, features = ["wgsl"] }
 bytemuck = { version = "1.21", features = ["derive"] }
 pollster = "0.4"
 thiserror = "2.0"
 log = "0.4"
-wide = "0.7"
+wide = "1.1"
 
 # WASM dependencies (optional)
 wasm-bindgen = { workspace = true, optional = true }
@@ -30,7 +30,7 @@ default = []
 wasm = ["wgpu/webgl", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [[bench]]

--- a/cliffy-loadtest/Cargo.toml
+++ b/cliffy-loadtest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliffy-loadtest"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Scale testing framework for Cliffy - simulates 100-10,000+ concurrent users"
 license = "MIT"
@@ -11,9 +11,9 @@ categories = ["development-tools::testing", "simulation"]
 
 [dependencies]
 # Core Cliffy crates
-cliffy-core = { version = "0.3.0", path = "../cliffy-core" }
-cliffy-protocols = { version = "0.3.0", path = "../cliffy-protocols" }
-cliffy-test = { version = "0.3.0", path = "../cliffy-test" }
+cliffy-core = { version = "0.3.1", path = "../cliffy-core" }
+cliffy-protocols = { version = "0.3.1", path = "../cliffy-protocols" }
+cliffy-test = { version = "0.3.1", path = "../cliffy-test" }
 
 # Geometric algebra
 amari-core = { workspace = true }
@@ -25,7 +25,7 @@ rayon = "1.10"
 tokio = { version = "1.48", features = ["rt", "rt-multi-thread", "time", "sync", "macros"] }
 
 # Random number generation
-rand = "0.8"
+rand = "0.10"
 
 # Unique IDs
 uuid = { version = "1.0", features = ["v4"] }

--- a/cliffy-loadtest/src/network.rs
+++ b/cliffy-loadtest/src/network.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides configurable network characteristics for realistic testing.
 
-use rand::Rng;
+use rand::RngExt;
 use std::time::Duration;
 
 /// Network topology for simulation
@@ -73,9 +73,9 @@ impl NetworkTopology {
             }
 
             Self::Random { edge_probability } => {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 (0..total_nodes)
-                    .filter(|&i| i != node_index && rng.gen::<f64>() < *edge_probability)
+                    .filter(|&i| i != node_index && rng.random::<f64>() < *edge_probability)
                     .collect()
             }
 
@@ -182,16 +182,16 @@ impl LatencyModel {
 
     /// Get a random latency value based on the model
     pub fn get_latency(&self) -> Duration {
-        let mut rng = rand::thread_rng();
-        let variance = (rng.gen::<f64>() - 0.5) * 2.0 * self.variance_ms;
-        let jitter_factor = 1.0 + (rng.gen::<f64>() - 0.5) * 2.0 * self.jitter;
+        let mut rng = rand::rng();
+        let variance = (rng.random::<f64>() - 0.5) * 2.0 * self.variance_ms;
+        let jitter_factor = 1.0 + (rng.random::<f64>() - 0.5) * 2.0 * self.jitter;
         let ms = ((self.base_ms + variance) * jitter_factor).max(0.0);
         Duration::from_secs_f64(ms / 1000.0)
     }
 
     /// Check if a packet should be dropped
     pub fn should_drop(&self) -> bool {
-        rand::thread_rng().gen::<f64>() < self.loss_rate
+        rand::rng().random::<f64>() < self.loss_rate
     }
 
     /// Get the expected average latency

--- a/cliffy-protocols/Cargo.toml
+++ b/cliffy-protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliffy-protocols"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Distributed consensus protocols using geometric algebra"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["distributed", "crdt", "consensus", "geometric-algebra", "sync"]
 categories = ["algorithms", "data-structures", "concurrency"]
 
 [dependencies]
-cliffy-core = { version = "0.3.0", path = "../cliffy-core" }
+cliffy-core = { version = "0.3.1", path = "../cliffy-core" }
 amari-core = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/cliffy-test/Cargo.toml
+++ b/cliffy-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliffy-test"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Algebraic testing framework for Cliffy - tests as geometric invariants"
 license = "MIT"
@@ -24,7 +24,7 @@ quickcheck_macros = "1.0"
 rayon = "1.10"
 
 # Random sampling
-rand = "0.8"
+rand = "0.10"
 
 # Serialization for test results
 serde = { workspace = true }

--- a/cliffy-test/src/invariants.rs
+++ b/cliffy-test/src/invariants.rs
@@ -385,15 +385,15 @@ mod tests {
 
     #[test]
     fn test_rare_invariant() {
-        use rand::Rng;
+        use rand::RngExt;
 
         // Invariant that fails ~10% of the time
         let inv = RareInvariant::new(
             "Rarely fails",
             0.2, // Allow up to 20% failure rate
             || {
-                let mut rng = rand::thread_rng();
-                if rng.gen::<f64>() < 0.1 {
+                let mut rng = rand::rng();
+                if rng.random::<f64>() < 0.1 {
                     TestResult::fail_with_distance(0.1, "Random failure")
                 } else {
                     TestResult::Pass
@@ -451,11 +451,11 @@ mod tests {
 
     #[test]
     fn test_rare_verify_with_smt() {
-        use rand::Rng;
+        use rand::RngExt;
 
         let inv = RareInvariant::new("Bounded failure", 0.2, || {
-            let mut rng = rand::thread_rng();
-            if rng.gen::<f64>() < 0.05 {
+            let mut rng = rand::rng();
+            if rng.random::<f64>() < 0.05 {
                 TestResult::fail_with_distance(0.1, "Random failure")
             } else {
                 TestResult::Pass

--- a/cliffy-test/src/macros.rs
+++ b/cliffy-test/src/macros.rs
@@ -88,14 +88,14 @@ macro_rules! invariant_impossible {
 /// ```rust
 /// use cliffy_test::invariant_rare;
 /// use cliffy_test::prelude::*;
-/// use rand::Rng;
+/// use rand::RngExt;
 ///
 /// let inv = invariant_rare! {
 ///     name: "Random value usually in range",
 ///     probability_bound: 0.1,  // Allow up to 10% failure rate
 ///     check: || {
-///         let mut rng = rand::thread_rng();
-///         let value: f64 = rng.gen_range(0.0..1.0);
+///         let mut rng = rand::rng();
+///         let value: f64 = rng.random_range(0.0..1.0);
 ///
 ///         if value < 0.95 {  // 95% of values should be < 0.95
 ///             TestResult::Pass

--- a/cliffy-tsukoshi/package.json
+++ b/cliffy-tsukoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliffy-ga/tsukoshi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Minimal geometric state management with distributed protocols - pure TypeScript, zero dependencies",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/cliffy-wasm/Cargo.toml
+++ b/cliffy-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliffy-wasm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "WebAssembly bindings for Cliffy reactive framework"
 license = "MIT"
@@ -29,15 +29,17 @@ web-sys = { workspace = true, features = [
     "Window",
 ] }
 console_error_panic_hook = { version = "0.1", optional = true }
-cliffy-core = { version = "0.3.0", path = "../cliffy-core" }
-cliffy-protocols = { version = "0.3.0", path = "../cliffy-protocols" }
-cliffy-test = { version = "0.3.0", path = "../cliffy-test" }
+cliffy-core = { version = "0.3.1", path = "../cliffy-core" }
+cliffy-protocols = { version = "0.3.1", path = "../cliffy-protocols" }
+cliffy-test = { version = "0.3.1", path = "../cliffy-test" }
 uuid = { version = "1.0", features = ["v4", "js"] }
-getrandom = { version = "0.2", features = ["js"] }
-# getrandom 0.4 is pulled in by cliffy-test -> quickcheck -> rand 0.10
-# Enable wasm_js feature for WASM target compatibility
+# getrandom 0.2 needed for uuid's transitive dep on wasm32
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
+# getrandom 0.3 needed for rand 0.10 on wasm32
+getrandom = { version = "0.3", features = ["wasm_js"] }
+# getrandom 0.4 pulled in by quickcheck -> rand; enable wasm_js for WASM target
 getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
-rand = "0.8"
+rand = "0.10"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/cliffy-wasm/src/test.rs
+++ b/cliffy-wasm/src/test.rs
@@ -514,19 +514,19 @@ pub fn test_rare(
 /// Generate a random GA3 multivector for property testing
 #[wasm_bindgen(js_name = randomGA3)]
 pub fn random_ga3() -> Vec<f64> {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    (0..8).map(|_| rng.gen_range(-10.0..10.0)).collect()
+    use rand::RngExt;
+    let mut rng = rand::rng();
+    (0..8).map(|_| rng.random_range(-10.0..10.0)).collect()
 }
 
 /// Generate a random unit vector for property testing
 #[wasm_bindgen(js_name = randomUnitVector)]
 pub fn random_unit_vector() -> Vec<f64> {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    let x: f64 = rng.gen_range(-1.0..1.0);
-    let y: f64 = rng.gen_range(-1.0..1.0);
-    let z: f64 = rng.gen_range(-1.0..1.0);
+    use rand::RngExt;
+    let mut rng = rand::rng();
+    let x: f64 = rng.random_range(-1.0..1.0);
+    let y: f64 = rng.random_range(-1.0..1.0);
+    let z: f64 = rng.random_range(-1.0..1.0);
     let mag = (x * x + y * y + z * z).sqrt();
     if mag > 1e-10 {
         vec![0.0, x / mag, y / mag, 0.0, z / mag, 0.0, 0.0, 0.0]
@@ -538,17 +538,17 @@ pub fn random_unit_vector() -> Vec<f64> {
 /// Generate a random rotor for property testing
 #[wasm_bindgen(js_name = randomRotor)]
 pub fn random_rotor() -> Vec<f64> {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
+    use rand::RngExt;
+    let mut rng = rand::rng();
 
     // Generate random angle
-    let angle: f64 = rng.gen_range(0.0..std::f64::consts::TAU);
+    let angle: f64 = rng.random_range(0.0..std::f64::consts::TAU);
     let half_angle = angle / 2.0;
 
     // Generate random axis
-    let x: f64 = rng.gen_range(-1.0..1.0);
-    let y: f64 = rng.gen_range(-1.0..1.0);
-    let z: f64 = rng.gen_range(-1.0..1.0);
+    let x: f64 = rng.random_range(-1.0..1.0);
+    let y: f64 = rng.random_range(-1.0..1.0);
+    let z: f64 = rng.random_range(-1.0..1.0);
     let mag = (x * x + y * y + z * z).sqrt();
 
     if mag < 1e-10 {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliffy/examples",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "workspaces": [
@@ -48,6 +48,6 @@
   "devDependencies": {
     "@playwright/test": "^1.40.0",
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cliffy",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "WASM-first reactive framework with classical FRP semantics and geometric algebra foundation",
   "type": "module",
   "scripts": {

--- a/tools/create-cliffy/package.json
+++ b/tools/create-cliffy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-cliffy",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Create a new Cliffy project - apps or component libraries",
   "type": "module",
   "bin": {
@@ -38,16 +38,16 @@
     "url": "https://github.com/Industrial-Algebra/cliffy/issues"
   },
   "dependencies": {
-    "commander": "^12.0.0",
+    "commander": "^14.0.0",
     "prompts": "^2.4.2",
     "picocolors": "^1.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^25.0.0",
     "@types/prompts": "^2.4.8",
     "typescript": "^5.3.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/vite-plugin-algebraic-tsx/package.json
+++ b/vite-plugin-algebraic-tsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-algebraic-tsx",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vite plugin to transform Algebraic TSX into Cliffy jsx() function calls",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
   "author": "Cliffy Team",
   "license": "MIT",
   "peerDependencies": {
-    "vite": "^4.0.0 || ^5.0.0"
+    "vite": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "@babel/parser": "^7.23.0",
@@ -40,7 +40,7 @@
     "@types/babel__types": "^7.20.0",
     "@types/babel__generator": "^7.6.0",
     "typescript": "^5.0.0",
-    "vite": "^4.4.0"
+    "vite": "^7.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Maintenance release bumping all dependencies flagged by Dependabot after v0.3.0.

- **Cargo**: wide 0.7→1.1, criterion 0.5→0.8, rand 0.8→0.10 (with API migration: `thread_rng`→`rng`, `gen`→`random`, `gen_range`→`random_range`, `Rng`→`RngExt`)
- **NPM**: vite ^4/^5→^7, commander ^12→^14, @types/node ^20→^25, engines.node ≥18→≥20
- **GitHub Actions**: upload-artifact v6→v7, download-artifact v4/v7→v8
- **Versions**: All crates and packages bumped 0.3.0 → 0.3.1

## Dependabot PRs Addressed

#159, #160, #161, #163, #164, #165, #166, #167, #169, #170

**Skipped:** #162 (wgpu 24→28, needs cliffy-gpu rework), #168 (@cliffy-ga/core, local file dep)

## Test plan

- [x] `cargo test --workspace` — 194 tests pass
- [x] `cargo test --doc` — 30 doctests pass
- [x] `wasm-pack build cliffy-wasm --target web` — WASM builds
- [x] `cd cliffy-tsukoshi && npx vitest run` — 113 tests pass
- [x] Pre-commit hooks (fmt, clippy, tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)